### PR TITLE
Menu: support nested children, update design

### DIFF
--- a/src/layout/Menu/Menu.examples.story.tsx
+++ b/src/layout/Menu/Menu.examples.story.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { Menu } from './Menu';
 
-import { Header } from '../../typography';
 import { Tip } from '../../components';
 import { PopOver } from '../PopOver/PopOver';
 import { Pop } from '../PopOver/PopOver.minors';
@@ -24,10 +23,10 @@ export function Simple() {
       <Menu style={{ padding: '1rem' }}>
         <Menu.Section title="Section 1">
           <Menu.Item active icon={<Home />}>
-            <Header size="4">Can be any element</Header>
+            Item 1 S1
           </Menu.Item>
           <Menu.Item href="#" icon={<Gear />}>
-            With href
+            Item 2 S1 (with href)
           </Menu.Item>
         </Menu.Section>
 

--- a/src/layout/Menu/Menu.examples.story.tsx
+++ b/src/layout/Menu/Menu.examples.story.tsx
@@ -42,7 +42,7 @@ export function Simple() {
 export function Complex() {
   return (
     <Layout.StoryVertical>
-      <Menu style={{ padding: '1rem' }}>
+      <Menu style={{ padding: '1rem 1rem' }}>
         <Menu.Section title="Section 1">
           <Menu.Item toggle>
             Item 1 S1

--- a/src/layout/Menu/Menu.minors.tsx
+++ b/src/layout/Menu/Menu.minors.tsx
@@ -204,11 +204,11 @@ function SubMenu({ open, children, indentation }) {
 }
 
 const useDoubleClick = (
-  onClickDouble,
-  onClick = null,
+  onClickDouble: MouseEventHandler,
+  onClick: MouseEventHandler = null,
   duration = 150
 ) => {
-  const timeout = useRef();
+  const timeout = useRef<ReturnType<typeof setTimeout>>();
 
   const cleartimeout = () => {
     if (timeout) {
@@ -230,6 +230,6 @@ const useDoubleClick = (
 
       if (clickDouble) onClickDouble(event);
     },
-    [onClick, onClickDouble]
+    [duration, onClick, onClickDouble]
   );
 };

--- a/src/layout/Menu/Menu.minors.tsx
+++ b/src/layout/Menu/Menu.minors.tsx
@@ -4,6 +4,9 @@ import React, {
   cloneElement,
   useRef,
   useCallback,
+  ReactNode,
+  MouseEventHandler,
+  CSSProperties,
 } from 'react';
 
 import {
@@ -32,20 +35,20 @@ export function Section({ children, title = null, ...props }) {
     </div>
   );
 }
-
-type ItemProps = {
+interface ItemProps {
   action?: {
-    icon: React.ReactNode;
-    onClick: React.MouseEventHandler;
+    icon: ReactNode;
+    onClick: MouseEventHandler;
   };
   active?: boolean;
-  animationDelay?: number;
+  animationDelay?: string;
   children: any;
   href?: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   indentation: number;
+  style?: CSSProperties;
   toggle?: boolean;
-};
+}
 
 export function Item({ children, ...props }: ItemProps) {
   const simple =
@@ -79,12 +82,13 @@ function SimpleItem({
   href,
   icon,
   indentation = 36,
+  style,
   ...props
 }: ItemProps) {
   const onClick = (e: MouseEvent) => action.onClick?.(e);
 
   return (
-    <Wrapper animationDelay={animationDelay}>
+    <Wrapper style={{ animationDelay, ...style }}>
       <ItemStyled
         active={active}
         as={href ? 'a' : 'button'}
@@ -111,12 +115,13 @@ function SimpleItem({
 function ComplexItem({
   action,
   active,
-  animationDelay = 0,
+  animationDelay = '0ms',
   children,
   href,
   icon,
   toggle = false,
   indentation = 36,
+  style,
   ...props
 }: ItemProps) {
   const [open, setOpen] = useState(!toggle);
@@ -127,7 +132,7 @@ function ComplexItem({
   const onClick = useDoubleClick(() => setOpen((open) => !open));
 
   return (
-    <Wrapper animationDelay={animationDelay}>
+    <Wrapper style={{ animationDelay, ...style }}>
       <Toggle
         href={href}
         indentation={indentation}
@@ -187,7 +192,7 @@ function SubMenu({ open, children, indentation }) {
   const { complex } = children;
 
   const childNested = (child, i) => {
-    const animationDelay = i * 20 + 120 / complex.length;
+    const animationDelay = i * 20 + 120 / complex.length + 'ms';
     return cloneElement(child, { indentation, animationDelay });
   };
 

--- a/src/layout/Menu/Menu.minors.tsx
+++ b/src/layout/Menu/Menu.minors.tsx
@@ -119,10 +119,7 @@ function ComplexItem({
   const onClickAction = (e: MouseEvent) => action.onClick?.(e);
 
   return (
-    <Wrapper
-      $height={open && children.length}
-      animationDelay={animationDelay}
-    >
+    <Wrapper animationDelay={animationDelay}>
       {toggle && (
         // TODO - Do we need to translate? How to do translations in Iris? Something to be passed in? Appropriate label?
         <Toggle

--- a/src/layout/Menu/Menu.minors.tsx
+++ b/src/layout/Menu/Menu.minors.tsx
@@ -28,13 +28,17 @@ export function Section({ children, title = null, ...props }) {
 }
 
 type ItemProps = {
-  action;
-  active;
-  children;
-  href;
-  icon;
-  paddingIncrement;
-  toggle;
+  action?: {
+    icon: React.ReactNode;
+    onClick: React.MouseEventHandler;
+  };
+  active?: boolean;
+  animationDelay: number;
+  children: any;
+  href?: string;
+  icon: React.ReactNode;
+  paddingIncrement: number;
+  toggle?: boolean;
 };
 
 export function Item({ children, ...props }: ItemProps) {
@@ -64,16 +68,17 @@ const PADDING_INCREMENT = 8;
 function SimpleItem({
   action,
   active,
+  animationDelay = 0,
   children,
   href,
   icon,
   paddingIncrement = PADDING_INCREMENT,
   ...props
-}) {
+}: ItemProps) {
   const onClick = (e: MouseEvent) => action.onClick?.(e);
 
   return (
-    <Wrapper>
+    <Wrapper animationDelay={animationDelay}>
       <ItemStyled
         active={active}
         as={href ? 'a' : 'button'}
@@ -100,20 +105,24 @@ function SimpleItem({
 function ComplexItem({
   action,
   active,
+  animationDelay = 0,
   children,
   href,
   icon,
   toggle = false,
   paddingIncrement = PADDING_INCREMENT,
   ...props
-}) {
+}: ItemProps) {
   const [open, setOpen] = useState(!toggle);
 
   const onClickToggle = () => toggle && setOpen((open) => !open);
   const onClickAction = (e: MouseEvent) => action.onClick?.(e);
 
   return (
-    <Wrapper $height={open && children.length}>
+    <Wrapper
+      $height={open && children.length}
+      animationDelay={animationDelay}
+    >
       {toggle && (
         // TODO - Do we need to translate? How to do translations in Iris? Something to be passed in? Appropriate label?
         <Toggle
@@ -149,10 +158,12 @@ function ComplexItem({
       {open && (
         <SubMenu total={children.complex.length}>
           {Array.isArray(children.complex)
-            ? children.complex.map((child) => {
+            ? children.complex.map((child, idx) => {
                 return cloneElement(child, {
                   paddingIncrement:
                     paddingIncrement + PADDING_INCREMENT,
+                  animationDelay:
+                    idx * 20 + 120 / children.complex.length,
                 });
               })
             : children.complex}

--- a/src/layout/Menu/Menu.minors.tsx
+++ b/src/layout/Menu/Menu.minors.tsx
@@ -37,7 +37,7 @@ type ItemProps = {
   children: any;
   href?: string;
   icon: React.ReactNode;
-  paddingIncrement: number;
+  indentation: number;
   toggle?: boolean;
 };
 
@@ -72,7 +72,7 @@ function SimpleItem({
   children,
   href,
   icon,
-  paddingIncrement = PADDING_INCREMENT,
+  indentation = 36,
   ...props
 }: ItemProps) {
   const onClick = (e: MouseEvent) => action.onClick?.(e);
@@ -84,7 +84,7 @@ function SimpleItem({
         as={href ? 'a' : 'button'}
         href={href}
         hasAction={Boolean(action)}
-        indentation={paddingIncrement}
+        indentation={indentation}
         {...props}
       >
         {action && (
@@ -110,7 +110,7 @@ function ComplexItem({
   href,
   icon,
   toggle = false,
-  paddingIncrement = PADDING_INCREMENT,
+  indentation = 36,
   ...props
 }: ItemProps) {
   const [open, setOpen] = useState(!toggle);
@@ -128,7 +128,7 @@ function ComplexItem({
           href={href}
           onClick={onClickToggle}
           open={open}
-          indentation={paddingIncrement}
+          indentation={indentation}
         >
           <Focus parent={Toggle} />
           <ChevronDown />
@@ -137,7 +137,7 @@ function ComplexItem({
 
       <ItemStyled
         active={active}
-        indentation={paddingIncrement}
+        indentation={indentation}
         hasAction={Boolean(action)}
         {...props}
       >
@@ -157,8 +157,7 @@ function ComplexItem({
           {Array.isArray(children.complex)
             ? children.complex.map((child, idx) => {
                 return cloneElement(child, {
-                  paddingIncrement:
-                    paddingIncrement + PADDING_INCREMENT,
+                  indentation: indentation + PADDING_INCREMENT,
                   animationDelay:
                     idx * 20 + 120 / children.complex.length,
                 });

--- a/src/layout/Menu/Menu.minors.tsx
+++ b/src/layout/Menu/Menu.minors.tsx
@@ -121,7 +121,6 @@ function ComplexItem({
   return (
     <Wrapper animationDelay={animationDelay}>
       {toggle && (
-        // TODO - Do we need to translate? How to do translations in Iris? Something to be passed in? Appropriate label?
         <Toggle
           aria-label="toggle sub-menu"
           as={href ? 'a' : 'button'}

--- a/src/layout/Menu/Menu.minors.tsx
+++ b/src/layout/Menu/Menu.minors.tsx
@@ -93,16 +93,26 @@ function ComplexItem({
 
   return (
     <Wrapper active={active} $height={open && children.length}>
-      <ItemStyled onClick={onClick} {...props}>
+      <ItemStyled
+        onClick={onClick}
+        {...props}
+        style={{
+          marginLeft: '-0.5rem',
+          width: 'calc(100% + 0.5rem)',
+          paddingLeft: '1.75rem',
+        }}
+      >
         {icon && icon}
         {children.simple}
-        <Focus parent={ItemStyled} />
+        <Focus
+          parent={ItemStyled}
+          // style={{ left: '-0.75rem', width: 'calc(100% + 1rem)' }}
+        />
       </ItemStyled>
 
       {toggle && (
         <Toggle open={open}>
           <ChevronDown />
-          <Focus parent={Toggle} />
         </Toggle>
       )}
 

--- a/src/layout/Menu/Menu.minors.tsx
+++ b/src/layout/Menu/Menu.minors.tsx
@@ -33,7 +33,7 @@ type ItemProps = {
     onClick: React.MouseEventHandler;
   };
   active?: boolean;
-  animationDelay: number;
+  animationDelay?: number;
   children: any;
   href?: string;
   icon: React.ReactNode;
@@ -68,7 +68,7 @@ const PADDING_INCREMENT = 8;
 function SimpleItem({
   action,
   active,
-  animationDelay = 0,
+  animationDelay,
   children,
   href,
   icon,

--- a/src/layout/Menu/Menu.minors.tsx
+++ b/src/layout/Menu/Menu.minors.tsx
@@ -73,8 +73,9 @@ function SimpleItem({
   const onClick = (e: MouseEvent) => action.onClick?.(e);
 
   return (
-    <Wrapper active={active}>
+    <Wrapper>
       <ItemStyled
+        active={active}
         as={href ? 'a' : 'button'}
         href={href}
         hasAction={Boolean(action)}
@@ -112,7 +113,7 @@ function ComplexItem({
   const onClickAction = (e: MouseEvent) => action.onClick?.(e);
 
   return (
-    <Wrapper active={active} $height={open && children.length}>
+    <Wrapper $height={open && children.length}>
       {toggle && (
         // TODO - Do we need to translate? How to do translations in Iris? Something to be passed in? Appropriate label?
         <Toggle
@@ -129,6 +130,7 @@ function ComplexItem({
       )}
 
       <ItemStyled
+        active={active}
         indentation={paddingIncrement}
         hasAction={Boolean(action)}
         {...props}

--- a/src/layout/Menu/Menu.minors.tsx
+++ b/src/layout/Menu/Menu.minors.tsx
@@ -26,55 +26,76 @@ export function Section({ children, title = null, ...props }) {
   );
 }
 
-export function Item({
-  action,
-  active,
-  children,
-  href,
-  toggle = false,
-  icon,
-  ...props
-}) {
-  const [open, setOpen] = useState(!toggle);
-
-  const doToggle = () => toggle && setOpen((open) => !open);
-
-  const doAction = (e: MouseEvent) => {
-    action.onClick && action.onClick(e);
-  };
-
-  const simpleKids =
+export function Item({ children, ...props }) {
+  const simple =
     typeof children === 'object' && !children.props
       ? children.flat().filter((child) => typeof child === 'string')
       : children;
 
-  let complexKids =
+  const complex =
     typeof children === 'object' &&
     !children.props &&
     children.flat().filter((child) => typeof child !== 'string');
 
   if (complexKids.length === 0) complexKids = false;
 
-  const link = simpleKids && href;
-  const $height = open && complexKids.length;
+  if (complex) {
+    const children = { simple, complex };
+    return <ComplexItem {...props}>{children}</ComplexItem>;
+  }
+
+  if (simple) {
+    const children = simple;
+    return <SimpleItem {...props}>{children}</SimpleItem>;
+  }
+}
+
+function SimpleItem({
+  active,
+  children,
+  href,
+  icon,
+  action,
+  ...props
+}) {
+  const onClick = (e: MouseEvent) => {
+    action.onClick && action.onClick(e);
+  };
 
   return (
-    <Wrapper active={active} $height={$height}>
-      <ItemStyled
-        onClick={doToggle}
-        as={link ? 'a' : 'button'}
-        href={href}
-        {...props}
-      >
+    <Wrapper active={active}>
+      <ItemStyled as={href ? 'a' : 'button'} href={href} {...props}>
         {action && (
-          <Action onClick={doAction}>
+          <Action onClick={onClick}>
             {action.icon}
             <Focus parent={Action} />
           </Action>
         )}
 
         {icon && icon}
-        {simpleKids}
+        {children}
+        <Focus parent={ItemStyled} />
+      </ItemStyled>
+    </Wrapper>
+  );
+}
+
+function ComplexItem({
+  active,
+  children,
+  icon,
+  toggle = false,
+  ...props
+}) {
+  const [open, setOpen] = useState(!toggle);
+
+  const onClick = () => toggle && setOpen((open) => !open);
+
+  return (
+    <Wrapper active={active} $height={open && children.length}>
+      <ItemStyled onClick={onClick} {...props}>
+        {icon && icon}
+        {children.simple}
         <Focus parent={ItemStyled} />
       </ItemStyled>
 
@@ -84,9 +105,8 @@ export function Item({
           <Focus parent={Toggle} />
         </Toggle>
       )}
-      {open && complexKids && (
-        <SubMenu total={complexKids.length}>{complexKids}</SubMenu>
-      )}
+
+      {open && <SubMenu>{children.complex}</SubMenu>}
     </Wrapper>
   );
 }

--- a/src/layout/Menu/Menu.props.story.tsx
+++ b/src/layout/Menu/Menu.props.story.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Menu } from './Menu';
 
 import { Layout } from '../../storybook';
-import { Folder, Home, Grid, Gear } from '../../icons';
+import { Folder, Home, Grid, Gear, Video } from '../../icons';
 
 export default { title: 'layout/Menu/Props', component: Menu };
 
@@ -25,6 +25,21 @@ export function Format() {
           <Menu.Item icon={<Folder />}>Item 1 S2</Menu.Item>
           <Menu.Item icon={<Grid />}>Item 2 S2</Menu.Item>
         </Menu.Section>
+
+        <Menu.Section title="Section 3">
+          <Menu.Item icon={<Folder />} toggle={true}>
+            Item 1 S3
+            <Menu.Item icon={<Folder />} toggle={true}>
+              Item 1 S3 - lvl 2
+              <Menu.Item icon={<Folder />}>
+                Item 1 S3 - lvl 3
+              </Menu.Item>
+            </Menu.Item>
+          </Menu.Item>
+          <Menu.Item icon={<Folder />} toggle={true}>
+            Item 2 S3
+          </Menu.Item>
+        </Menu.Section>
       </Menu>
 
       <Menu format="secondary" style={{ padding: '1rem' }}>
@@ -38,6 +53,21 @@ export function Format() {
         <Menu.Section title="Section 2">
           <Menu.Item icon={<Folder />}>Item 1 S2</Menu.Item>
           <Menu.Item icon={<Grid />}>Item 2 S2</Menu.Item>
+        </Menu.Section>
+
+        <Menu.Section title="Section 3">
+          <Menu.Item icon={<Folder />} toggle={true}>
+            Item 1 S3
+            <Menu.Item icon={<Folder />} toggle={true}>
+              Item 1 S3 - lvl 2
+              <Menu.Item icon={<Folder />}>
+                Item 1 S3 - lvl 3
+              </Menu.Item>
+            </Menu.Item>
+          </Menu.Item>
+          <Menu.Item icon={<Folder />} toggle={true}>
+            Item 2 S3
+          </Menu.Item>
         </Menu.Section>
       </Menu>
     </Layout.StoryVertical>

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -73,6 +73,7 @@ export const Wrapper = styled.div<{
 }>`
   border-radius: 0.2rem;
   position: relative;
+  transition: 80ms ease-in-out;
   background: ${({ active, theme }) =>
     active &&
     (theme.name === 'dark'
@@ -87,7 +88,7 @@ export const Wrapper = styled.div<{
     p.$height &&
     css`
       transition: 230ms ease-in-out;
-      height: ${(p.$height + 1) * 2.5 + 0.25}rem;
+      height: ${(p.$height + 1) * 2.5 + 0.75}rem;
     `}
 
   > svg {

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -26,8 +26,9 @@ export const Action = styled.button`
 `;
 
 export const Toggle = styled.button<{
-  open?: boolean;
+  href?: string;
   indentation: number;
+  open?: boolean;
 }>`
   width: 1.25rem;
   height: 1.25rem;
@@ -83,6 +84,7 @@ const fade = keyframes`
 export const ItemStyled = styled.button<{
   active?: boolean;
   hasAction: boolean;
+  href?: string;
   indentation: number;
 }>`
   padding: 0.5rem;

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -151,20 +151,23 @@ export const MenuStyled = styled.div<{
       : 'none'};
 `;
 
-export const SubMenu = styled.div<{ total: number }>`
+const animation = css`
+  animation: ${fade} 140ms ease-in-out both;
+
+  ${[...Array(30)].map(
+    (_, i) => css`
+      &:nth-child(${i + 1}) {
+        animation-delay: ${(i + 1) * 40}ms;
+      }
+    `
+  )};
+`;
+
+export const SubMenu = styled.div`
   width: 100%;
-  padding-top: 0.25rem;
+  padding-left: 0.5rem;
 
   > div {
-    animation: ${fade} 120ms ease-in-out both;
-
-    ${(p) =>
-      [...new Array(30)].map(
-        (_, i) => css`
-          &:nth-child(${i}) {
-            animation-delay: ${i * (20 + 100 / p.total)}ms;
-          }
-        `
-      )};
+    ${animation};
   }
 `;

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -153,9 +153,7 @@ export const SubMenu = styled.div`
   width: 100%;
 `;
 
-export const Wrapper = styled.div<{
-  animationDelay: number;
-}>`
+export const Wrapper = styled.div`
   border-radius: 0.2rem;
   position: relative;
   transition: 80ms ease-in-out;
@@ -164,11 +162,10 @@ export const Wrapper = styled.div<{
     background: ${itemHoverColor};
   }
 
-  ${({ animationDelay }) =>
-    animationDelay &&
+  ${(p) =>
+    p.style.animationDelay &&
     css`
       animation: ${fade} 140ms ease-in-out both;
-      animation-delay: ${animationDelay}ms;
     `}
 
   > svg {

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -163,8 +163,12 @@ export const Wrapper = styled.div<{
     background: ${itemHoverColor};
   }
 
-  animation: ${fade} 140ms ease-in-out both;
-  animation-delay: ${({ animationDelay }) => `${animationDelay}ms`};
+  ${({ animationDelay }) =>
+    animationDelay &&
+    css`
+      animation: ${fade} 140ms ease-in-out both;
+      animation-delay: ${animationDelay}ms;
+    `}
 
   > svg {
     width: 1.125rem;

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -2,6 +2,7 @@ import styled, { css, keyframes } from 'styled-components';
 import { rem, rgba } from 'polished';
 
 import { grayscale, slate } from '../../color';
+import { core } from '../../tokens/core';
 
 export const Action = styled.button`
   position: absolute;
@@ -59,7 +60,7 @@ export const Toggle = styled.button<{
 
 export const Header = styled.div`
   display: block;
-  padding: 0.5rem 1.25rem;
+  padding: 0.5rem 1.25rem 0.5rem 2rem;
   text-transform: uppercase;
   margin: 0.2rem 0 0;
   color: ${(p) => rgba(p.theme.content.color, 0.5)};
@@ -128,12 +129,10 @@ export const MenuStyled = styled.div<{
   width: 20rem;
   border-radius: 0.25rem;
   color: ${({ theme }) => theme.content.color};
-  background: ${({ theme, format }) =>
+  background: ${({ format }) =>
     format === 'secondary'
-      ? theme.name === 'dark'
-        ? grayscale(970)
-        : slate(30)
-      : 'none'};
+      ? core.color.background(200)
+      : core.color.background(600)};
 `;
 
 const animation = css`

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -153,7 +153,6 @@ export const SubMenu = styled.div`
 `;
 
 export const Wrapper = styled.div<{
-  $height?: number;
   animationDelay: number;
 }>`
   border-radius: 0.2rem;
@@ -166,13 +165,6 @@ export const Wrapper = styled.div<{
 
   animation: ${fade} 140ms ease-in-out both;
   animation-delay: ${({ animationDelay }) => `${animationDelay}ms`};
-
-  ${(p) =>
-    p.$height &&
-    css`
-      transition: 230ms ease-in-out;
-      height: ${(p.$height + 1) * 2.5 + 0.75}rem;
-    `}
 
   > svg {
     width: 1.125rem;

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -39,8 +39,7 @@ export const Toggle = styled.button<{
   }
 
   &:hover {
-    background: ${({ theme }) =>
-      theme.name === 'dark' ? grayscale(600) : slate(200)};
+    background: ${toggleHoverColor};
   }
 
   border: 0px;
@@ -95,19 +94,14 @@ export const ItemStyled = styled.button<{
   font-size: 0.875rem;
   width: 100%;
   background: ${({ active, theme }) =>
-    active
-      ? theme.name === 'dark'
-        ? grayscale(700)
-        : slate(100)
-      : 'transparent'};
+    active ? itemHoverColor({ theme }) : 'transparent'};
   color: ${({ theme }) => theme.content.color};
   border: 0;
   cursor: pointer;
   transition: background 120ms ease-in-out;
 
   &:hover {
-    background: ${({ theme }) =>
-      theme.name === 'dark' ? grayscale(700) : slate(100)};
+    background: ${itemHoverColor};
   }
 
   &:focus {
@@ -156,23 +150,22 @@ const animation = css`
 
 export const SubMenu = styled.div`
   width: 100%;
-
-  > div {
-    ${animation};
-  }
 `;
 
 export const Wrapper = styled.div<{
   $height?: number;
+  animationDelay: number;
 }>`
   border-radius: 0.2rem;
   position: relative;
   transition: 80ms ease-in-out;
 
   & ${Toggle}:hover + ${ItemStyled} {
-    background: ${({ theme }) =>
-      theme.name === 'dark' ? grayscale(700) : slate(100)};
+    background: ${itemHoverColor};
   }
+
+  animation: ${fade} 140ms ease-in-out both;
+  animation-delay: ${({ animationDelay }) => `${animationDelay}ms`};
 
   ${(p) =>
     p.$height &&
@@ -198,3 +191,11 @@ export const TextContainer = styled.span`
   text-overflow: ellipsis;
   overflow: hidden;
 `;
+
+function itemHoverColor({ theme }) {
+  return theme.name === 'dark' ? grayscale(700) : slate(100);
+}
+
+function toggleHoverColor({ theme }) {
+  return theme.name === 'dark' ? grayscale(600) : slate(200);
+}

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -33,7 +33,7 @@ export const Toggle = styled.button<{
   height: 1.25rem;
   position: absolute;
   top: 0.625rem;
-  left: ${({ indentation }) => rem(indentation)};
+  left: ${({ indentation }) => rem(indentation - 28)};
 
   &:focus {
     outline: none;
@@ -87,7 +87,7 @@ export const ItemStyled = styled.button<{
 }>`
   padding: 0.5rem;
   padding-right: ${(p) => (p.hasAction ? '1.5rem' : '0.5rem')};
-  padding-left: ${({ indentation }) => rem(28 + indentation)};
+  padding-left: ${({ indentation }) => rem(indentation)};
   display: flex;
   position: relative;
   align-items: center;

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from 'styled-components';
-import { rem, rgba } from 'polished';
+import { rgba } from 'polished';
 
 import { grayscale, slate } from '../../color';
 import { core } from '../../tokens/core';
@@ -27,14 +27,12 @@ export const Action = styled.button`
 
 export const Toggle = styled.button<{
   href?: string;
-  indentation: number;
   open?: boolean;
 }>`
   width: 1.25rem;
   height: 1.25rem;
   position: absolute;
   top: 0.625rem;
-  left: ${({ indentation }) => rem(indentation - 28)};
 
   &:focus {
     outline: none;
@@ -83,13 +81,11 @@ const fade = keyframes`
 
 export const ItemStyled = styled.button<{
   active?: boolean;
-  hasAction: boolean;
+  action: boolean;
   href?: string;
-  indentation: number;
 }>`
   padding: 0.5rem;
-  padding-right: ${(p) => (p.hasAction ? '1.5rem' : '0.5rem')};
-  padding-left: ${({ indentation }) => rem(indentation)};
+  padding-right: ${(p) => (p.action ? '1.5rem' : '0.5rem')};
   display: flex;
   position: relative;
   align-items: center;
@@ -130,6 +126,7 @@ export const MenuStyled = styled.div<{
   display: block;
   width: 20rem;
   border-radius: 0.25rem;
+  padding: 1rem;
   color: ${({ theme }) => theme.content.color};
   background: ${({ format }) =>
     format === 'secondary'
@@ -177,6 +174,12 @@ export const Wrapper = styled.div`
     * {
       fill: ${({ theme }) => rgba(theme.content.color, 0.667)};
     }
+  }
+`;
+
+export const WrapperSection = styled.div`
+  > ${Wrapper} {
+    width: 100%;
   }
 `;
 

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from 'styled-components';
-import { lighten, rgba } from 'polished';
+import { rem, rgba } from 'polished';
 
 import { grayscale, slate } from '../../color';
 
@@ -24,21 +24,34 @@ export const Action = styled.button`
   }
 `;
 
-export const Toggle = styled.div<{ open?: boolean }>`
-  width: 1.5rem;
-  height: 1.5rem;
+export const Toggle = styled.button<{
+  open?: boolean;
+  indentation: number;
+}>`
+  width: 1.25rem;
+  height: 1.25rem;
   position: absolute;
-  top: 0.5rem;
-  left: -0.5rem;
-  transition: 120ms ease-in-out;
-
-  transform: ${(p) => (p.open ? 'rotate(0deg)' : 'rotate(-90deg)')};
+  top: 0.625rem;
+  left: ${({ indentation }) => rem(indentation)};
 
   &:focus {
     outline: none;
   }
 
+  &:hover {
+    background: ${({ theme }) =>
+      theme.name === 'dark' ? grayscale(600) : slate(200)};
+  }
+
+  border: 0px;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  z-index: 1;
+
   > svg {
+    transition: 120ms ease-in-out;
+    transform: ${(p) => (p.open ? 'rotate(0deg)' : 'rotate(-90deg)')};
+
     * {
       fill: ${({ theme }) => theme.content.color};
     }
@@ -67,63 +80,27 @@ const fade = keyframes`
   }
 `;
 
-export const Wrapper = styled.div<{
-  active?: boolean;
-  $height?: number;
+export const ItemStyled = styled.button<{
+  indentation: number;
+  hasAction: boolean;
 }>`
-  border-radius: 0.2rem;
-  position: relative;
-  transition: 80ms ease-in-out;
-
-  /*
-  background: ${({ active, theme }) =>
-    active &&
-    (theme.name === 'dark'
-      ? rgba(theme.content.color, 0.095)
-      : rgba(theme.content.color, 0.065))};
-
-  &:hover {
-    background: ${({ theme }) => rgba(theme.content.color, 0.025)};
-  }
-  */
-
-  ${(p) =>
-    p.$height &&
-    css`
-      transition: 230ms ease-in-out;
-      height: ${(p.$height + 1) * 2.5 + 0.75}rem;
-    `}
-
-  > svg {
-    width: 1.125rem;
-    height: 1.125rem;
-    margin: 0 0.5rem 0 0;
-    display: inline-block;
-
-    * {
-      fill: ${({ theme }) => rgba(theme.content.color, 0.667)};
-    }
-  }
-`;
-
-export const ItemStyled = styled.button<any>`
-  padding: 0.5rem 1.25rem;
+  padding: 0.5rem;
+  padding-right: ${(p) => (p.hasAction ? '1.5rem' : '0.5rem')};
+  padding-left: ${({ indentation }) => rem(28 + indentation)};
   display: flex;
-  flex-wrap: wrap;
   position: relative;
   align-items: center;
   line-height: 1.5rem;
-  border-radius: 0.2rem;
   font-size: 0.875rem;
   width: 100%;
   background: transparent;
   color: ${({ theme }) => theme.content.color};
   border: 0;
   cursor: pointer;
-  background: ${({ theme }) => lighten(0.96, theme.content.color)};
 
   &:hover {
-    background: ${({ theme }) => lighten(0.92, theme.content.color)};
+    background: ${({ theme }) =>
+      theme.name === 'dark' ? grayscale(700) : slate(100)};
   }
 
   &:focus {
@@ -133,10 +110,12 @@ export const ItemStyled = styled.button<any>`
   > svg {
     width: 1.125rem;
     height: 1.125rem;
-    margin-right: 1rem;
+    min-width: 1.125rem;
+    min-height: 1.125rem;
+    margin-right: 0.5rem;
 
     * {
-      fill: ${({ theme }) => rgba(theme.content.color, 0.667)};
+      fill: ${({ theme }) => theme.content.color};
     }
   }
 `;
@@ -170,9 +149,46 @@ const animation = css`
 
 export const SubMenu = styled.div`
   width: 100%;
-  padding-left: 0.5rem;
 
   > div {
     ${animation};
   }
+`;
+
+export const Wrapper = styled.div<{
+  active?: boolean;
+  $height?: number;
+}>`
+  border-radius: 0.2rem;
+  position: relative;
+  transition: 80ms ease-in-out;
+
+  & ${Toggle}:hover + ${ItemStyled} {
+    background: ${({ theme }) =>
+      theme.name === 'dark' ? grayscale(700) : slate(100)};
+  }
+
+  ${(p) =>
+    p.$height &&
+    css`
+      transition: 230ms ease-in-out;
+      height: ${(p.$height + 1) * 2.5 + 0.75}rem;
+    `}
+
+  > svg {
+    width: 1.125rem;
+    height: 1.125rem;
+    margin: 0 0.5rem 0 0;
+    display: inline-block;
+
+    * {
+      fill: ${({ theme }) => rgba(theme.content.color, 0.667)};
+    }
+  }
+`;
+
+export const TextContainer = styled.span`
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 `;

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from 'styled-components';
-import { rgba } from 'polished';
+import { lighten, rgba } from 'polished';
 
 import { grayscale, slate } from '../../color';
 
@@ -74,6 +74,8 @@ export const Wrapper = styled.div<{
   border-radius: 0.2rem;
   position: relative;
   transition: 80ms ease-in-out;
+
+  /*
   background: ${({ active, theme }) =>
     active &&
     (theme.name === 'dark'
@@ -83,6 +85,7 @@ export const Wrapper = styled.div<{
   &:hover {
     background: ${({ theme }) => rgba(theme.content.color, 0.025)};
   }
+  */
 
   ${(p) =>
     p.$height &&
@@ -117,9 +120,10 @@ export const ItemStyled = styled.button<any>`
   color: ${({ theme }) => theme.content.color};
   border: 0;
   cursor: pointer;
+  background: ${({ theme }) => lighten(0.96, theme.content.color)};
 
   &:hover {
-    background: ${({ theme }) => rgba(theme.content.color, 0.05)};
+    background: ${({ theme }) => lighten(0.92, theme.content.color)};
   }
 
   &:focus {

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -81,8 +81,9 @@ const fade = keyframes`
 `;
 
 export const ItemStyled = styled.button<{
-  indentation: number;
+  active?: boolean;
   hasAction: boolean;
+  indentation: number;
 }>`
   padding: 0.5rem;
   padding-right: ${(p) => (p.hasAction ? '1.5rem' : '0.5rem')};
@@ -93,7 +94,12 @@ export const ItemStyled = styled.button<{
   line-height: 1.5rem;
   font-size: 0.875rem;
   width: 100%;
-  background: transparent;
+  background: ${({ active, theme }) =>
+    active
+      ? theme.name === 'dark'
+        ? grayscale(700)
+        : slate(100)
+      : 'transparent'};
   color: ${({ theme }) => theme.content.color};
   border: 0;
   cursor: pointer;
@@ -156,7 +162,6 @@ export const SubMenu = styled.div`
 `;
 
 export const Wrapper = styled.div<{
-  active?: boolean;
   $height?: number;
 }>`
   border-radius: 0.2rem;

--- a/src/layout/Menu/Menu.style.ts
+++ b/src/layout/Menu/Menu.style.ts
@@ -103,6 +103,7 @@ export const ItemStyled = styled.button<{
   color: ${({ theme }) => theme.content.color};
   border: 0;
   cursor: pointer;
+  transition: background 120ms ease-in-out;
 
   &:hover {
     background: ${({ theme }) =>

--- a/src/layout/Menu/Menu.tsx
+++ b/src/layout/Menu/Menu.tsx
@@ -1,9 +1,14 @@
-import React from 'react';
+import React, { cloneElement, useState } from 'react';
 
 import { MenuStyled } from './Menu.style';
 import { Section, Item, Minors } from './Menu.minors';
 
-import { withIris, IrisProps } from '../../utils';
+import {
+  withIris,
+  IrisProps,
+  useForwardRef,
+  useIsomorphicEffect,
+} from '../../utils';
 
 export const Menu = withIris<HTMLDivElement, Props, Minors>(
   MenuComponent
@@ -25,13 +30,41 @@ export type Props = IrisProps<
 
 function MenuComponent({
   children,
+  className,
   format = 'secondary',
   forwardRef,
+  // OPTIONAL SEPARATE INDENTATION FROM PADDING
+  // indentation,
+  style,
   ...props
 }: Props) {
+  const ref = useForwardRef(forwardRef);
+  const [indentation, indentationSet] = useState([0, 0]);
+
+  useIsomorphicEffect(() => {
+    const { paddingLeft } = getComputedStyle(ref.current);
+
+    const indentation = parseInt(paddingLeft);
+    indentationSet([indentation, indentation]);
+  }, [style, className]);
+
+  console.log('a', { indentation });
+
+  const childrenCloned = Array.isArray(children)
+    ? children.map((child) => cloneElement(child, { indentation }))
+    : cloneElement(children, { indentation });
+
+  console.log({ childrenCloned });
+
   return (
-    <MenuStyled ref={forwardRef} format={format} {...props}>
-      {children}
+    <MenuStyled
+      className={className}
+      format={format}
+      ref={ref}
+      style={style}
+      {...props}
+    >
+      {childrenCloned}
     </MenuStyled>
   );
 }

--- a/src/layout/Menu/examples/SideNav.tsx
+++ b/src/layout/Menu/examples/SideNav.tsx
@@ -220,5 +220,5 @@ const ContentContainer = styled.div`
 
 const FoldersContainer = styled.div`
   flex-grow: 1;
-  overflow-x: scroll;
+  overflow-y: scroll;
 `;

--- a/src/layout/Menu/examples/SideNav.tsx
+++ b/src/layout/Menu/examples/SideNav.tsx
@@ -37,7 +37,7 @@ export function SideNav() {
           Home
           <Menu.Item toggle>
             Product
-            <Menu.Item active={true} toggle>
+            <Menu.Item toggle>
               Panels
               <Menu.Item toggle>
                 November 2020

--- a/src/layout/Menu/examples/SideNav.tsx
+++ b/src/layout/Menu/examples/SideNav.tsx
@@ -34,122 +34,117 @@ export function SideNav() {
     >
       <MenuContainer>
         <Menu.Item active={true} toggle icon={<Home />}>
-          {'Home'}
+          Home
           <Menu.Item toggle>
-            {'Product'}
+            Product
             <Menu.Item active={true} toggle>
-              {'Panels'}
+              Panels
               <Menu.Item toggle>
-                {'November 2020'}
+                November 2020
                 <Menu.Item toggle>
-                  {'rough cuts'}
-                  <Menu.Item toggle>{'clips'}</Menu.Item>
+                  Folder with a long name
+                  <Menu.Item toggle>
+                    Another folder with a long name
+                  </Menu.Item>
                 </Menu.Item>
               </Menu.Item>
               <Menu.Item toggle>
-                {'October 2020'}
-                <Menu.Item toggle>{'rough cuts'}</Menu.Item>
+                October 2020
+                <Menu.Item toggle>rough cuts</Menu.Item>
               </Menu.Item>
             </Menu.Item>
           </Menu.Item>
           <Menu.Item toggle>
-            {'Engineering'}
+            Engineering
             <Menu.Item toggle>
-              {'Panels'}
+              Panels
               <Menu.Item toggle>
-                {'November 2020'}
+                November 2020
                 <Menu.Item toggle>
-                  {'rough cuts'}
-                  <Menu.Item toggle>{'clips'}</Menu.Item>
+                  rough cuts
+                  <Menu.Item toggle>clips</Menu.Item>
                 </Menu.Item>
               </Menu.Item>
               <Menu.Item toggle>
-                {'October 2020'}
-                <Menu.Item toggle>{'rough cuts'}</Menu.Item>
+                October 2020
+                <Menu.Item toggle>rough cuts</Menu.Item>
               </Menu.Item>
             </Menu.Item>
           </Menu.Item>
           <Menu.Item toggle>
-            {'Marketing'}
+            Marketing
             <Menu.Item toggle>
-              {'Panels'}
+              Panels
               <Menu.Item toggle>
-                {'November 2020'}
+                November 2020
                 <Menu.Item toggle>
-                  {'rough cuts'}
-                  <Menu.Item toggle>{'clips'}</Menu.Item>
+                  rough cuts
+                  <Menu.Item toggle>clips</Menu.Item>
                 </Menu.Item>
               </Menu.Item>
               <Menu.Item toggle>
-                {'October 2020'}
-                <Menu.Item toggle>{'rough cuts'}</Menu.Item>
+                October 2020
+                <Menu.Item toggle>rough cuts</Menu.Item>
               </Menu.Item>
             </Menu.Item>
           </Menu.Item>
-
           <Menu.Item toggle>
-            {'Sales'}
+            Sales
             <Menu.Item toggle>
-              {'Panels'}
+              Panels
               <Menu.Item toggle>
-                {'November 2020'}
+                November 2020
                 <Menu.Item toggle>
-                  {'rough cuts'}
-                  <Menu.Item toggle>{'clips'}</Menu.Item>
+                  rough cuts
+                  <Menu.Item toggle>clips</Menu.Item>
                 </Menu.Item>
               </Menu.Item>
               <Menu.Item toggle>
-                {'October 2020'}
-                <Menu.Item toggle>{'rough cuts'}</Menu.Item>
+                October 2020
+                <Menu.Item toggle>rough cuts</Menu.Item>
               </Menu.Item>
             </Menu.Item>
           </Menu.Item>
-
           <Menu.Item toggle>
-            {'IT'}
+            IT
             <Menu.Item toggle>
-              {'Panels'}
+              Panels
               <Menu.Item toggle>
-                {'November 2020'}
+                November 2020
                 <Menu.Item toggle>
-                  {'rough cuts'}
-                  <Menu.Item toggle>{'clips'}</Menu.Item>
+                  rough cuts
+                  <Menu.Item toggle>clips</Menu.Item>
                 </Menu.Item>
               </Menu.Item>
               <Menu.Item toggle>
-                {'October 2020'}
-                <Menu.Item toggle>{'rough cuts'}</Menu.Item>
+                October 2020
+                <Menu.Item toggle>rough cuts</Menu.Item>
               </Menu.Item>
             </Menu.Item>
           </Menu.Item>
-
-          <Menu.Item>{'Onboarding'}</Menu.Item>
-
-          <Menu.Item toggle>{'Leagal'}</Menu.Item>
-
-          <Menu.Item>{'All Hands'}</Menu.Item>
-
-          <Menu.Item toggle>{'Archived'}</Menu.Item>
+          <Menu.Item>Onboarding</Menu.Item>
+          <Menu.Item toggle>Leagal</Menu.Item>
+          <Menu.Item>All Hands</Menu.Item>
+          <Menu.Item toggle>Archived</Menu.Item>
         </Menu.Item>
       </MenuContainer>
 
       <MenuContainer>
         <Menu.Item toggle icon={<Lock />}>
-          {'Private to me'}
-          <Menu.Item>{'WIP'}</Menu.Item>
-          <Menu.Item>{'Recordings'}</Menu.Item>
+          Private to me
+          <Menu.Item>WIP</Menu.Item>
+          <Menu.Item>Recordings</Menu.Item>
           <Menu.Item toggle>
-            {'Drafts'}
-            <Menu.Item>{'Subfolder'}</Menu.Item>
-          </Menu.Item>
-
-          <Menu.Item toggle>
-            {'Meetings'}
-            <Menu.Item>{'Subfolder'}</Menu.Item>
+            Drafts
+            <Menu.Item>Subfolder</Menu.Item>
           </Menu.Item>
           <Menu.Item toggle>
-            {'Machinations'}
-            <Menu.Item>{'Subfolder'}</Menu.Item>
+            Meetings
+            <Menu.Item>Subfolder</Menu.Item>
+          </Menu.Item>
+          <Menu.Item toggle>
+            Machinations
+            <Menu.Item>Subfolder</Menu.Item>
           </Menu.Item>
         </Menu.Item>
       </MenuContainer>
@@ -160,12 +155,12 @@ export function SideNav() {
     <ContentContainer>
       <TopAnchored>
         <Button fluid format="secondary">
-          {'Manage Videos'}
+          Manage Videos
         </Button>
       </TopAnchored>
       <FoldersContainer>{folders}</FoldersContainer>
       <BottomAnchored>
-        <Menu.Item icon={<Person />}>{'Manage Team'}</Menu.Item>
+        <Menu.Item icon={<Person />}>Manage Team</Menu.Item>
       </BottomAnchored>
     </ContentContainer>
   );
@@ -176,6 +171,7 @@ export function SideNav() {
       attach="left"
       screen={false}
       content={content}
+      resizable={true}
     />
   );
 }

--- a/src/layout/Menu/examples/SideNav.tsx
+++ b/src/layout/Menu/examples/SideNav.tsx
@@ -31,7 +31,7 @@ export function SideNav() {
       format="basic"
     >
       <MenuContainer>
-        <Menu.Item toggle icon={<Home />}>
+        <Menu.Item active={true} toggle icon={<Home />}>
           {'Home'}
           <Menu.Item toggle>
             {'Product'}

--- a/src/layout/Menu/examples/SideNav.tsx
+++ b/src/layout/Menu/examples/SideNav.tsx
@@ -31,7 +31,7 @@ export function SideNav() {
       }}
       format="basic"
     >
-      <MenuContainer>
+      <Menu.Section>
         <Menu.Item active={true} toggle icon={<Home />}>
           Home
           <Menu.Item toggle>
@@ -126,9 +126,8 @@ export function SideNav() {
           <Menu.Item>All Hands</Menu.Item>
           <Menu.Item toggle>Archived</Menu.Item>
         </Menu.Item>
-      </MenuContainer>
-
-      <MenuContainer>
+      </Menu.Section>
+      <Menu.Section>
         <Menu.Item toggle icon={<Lock />}>
           Private to me
           <Menu.Item>WIP</Menu.Item>
@@ -146,7 +145,7 @@ export function SideNav() {
             <Menu.Item>Subfolder</Menu.Item>
           </Menu.Item>
         </Menu.Item>
-      </MenuContainer>
+      </Menu.Section>
     </Menu>
   );
 
@@ -175,18 +174,18 @@ export function SideNav() {
   );
 }
 
-const MenuContainer = styled.div`
-  padding: 1rem 0;
-  position: relative;
-  &:not(:only-child):after {
-    content: '';
-    height: 1px;
-    width: 100%;
-    position: absolute;
-    bottom: 0px;
-    background-color: ${core.color.stroke};
-  }
-`;
+// const MenuContainer = styled.div`
+//   padding: 1rem 0;
+//   position: relative;
+//   &:not(:only-child):after {
+//     content: '';
+//     height: 1px;
+//     width: 100%;
+//     position: absolute;
+//     bottom: 0px;
+//     background-color: ${core.color.stroke};
+//   }
+// `;
 
 const TopAnchored = styled.div`
   flex-shrink: 0;

--- a/src/layout/Menu/examples/SideNav.tsx
+++ b/src/layout/Menu/examples/SideNav.tsx
@@ -6,12 +6,11 @@ import { Menu } from '../Menu';
 import { Panel } from '../../Panel/Panel';
 import { Home, Lock, Person } from '../../../icons';
 import { core } from '../../../tokens/';
-import { grayscale, white } from '../../../color';
 
 const StyledPanel = styled(Panel)`
-  ${core.edge(0)};
-  background-color: ${({ theme }) =>
-    theme.name === 'dark' ? grayscale(850) : white};
+  border-right: 1px solid ${core.color.stroke};
+  box-shadow: none;
+  background-color: ${core.color.background(600)};
 `;
 
 const dividerCSS = css`

--- a/src/layout/Menu/examples/SideNav.tsx
+++ b/src/layout/Menu/examples/SideNav.tsx
@@ -221,4 +221,5 @@ const ContentContainer = styled.div`
 const FoldersContainer = styled.div`
   flex-grow: 1;
   overflow-y: scroll;
+  overflow-x: hidden;
 `;

--- a/src/layout/Menu/examples/SideNav.tsx
+++ b/src/layout/Menu/examples/SideNav.tsx
@@ -4,12 +4,14 @@ import styled, { css } from 'styled-components';
 import { Button } from '../../../components/';
 import { Menu } from '../Menu';
 import { Panel } from '../../Panel/Panel';
-import { Home, Lock } from '../../../icons';
+import { Home, Lock, Person } from '../../../icons';
 import { core } from '../../../tokens/';
+import { grayscale, white } from '../../../color';
 
 const StyledPanel = styled(Panel)`
   ${core.edge(0)};
-  background-color: ${core.color.background(800)};
+  background-color: ${({ theme }) =>
+    theme.name === 'dark' ? grayscale(850) : white};
 `;
 
 const dividerCSS = css`
@@ -163,9 +165,7 @@ export function SideNav() {
       </TopAnchored>
       <FoldersContainer>{folders}</FoldersContainer>
       <BottomAnchored>
-        <Button fluid format="secondary">
-          {'Manage Team'}
-        </Button>
+        <Menu.Item icon={<Person />}>{'Manage Team'}</Menu.Item>
       </BottomAnchored>
     </ContentContainer>
   );
@@ -181,7 +181,7 @@ export function SideNav() {
 }
 
 const MenuContainer = styled.div`
-  padding: 16px 0;
+  padding: 1rem 0;
   position: relative;
   &:not(:only-child):after {
     content: '';
@@ -195,7 +195,7 @@ const MenuContainer = styled.div`
 
 const TopAnchored = styled.div`
   flex-shrink: 0;
-  padding: 0 16px 16px 16px;
+  padding: 0 1rem 1rem 1rem;
   position: relative;
   &:after {
     ${dividerCSS};
@@ -206,7 +206,7 @@ const TopAnchored = styled.div`
 const BottomAnchored = styled.div`
   position: relative;
   flex-shrink: 0;
-  padding: 16px 16px 0 16px;
+  padding-top: 1rem;
   &:before {
     ${dividerCSS};
     top: 0;
@@ -217,7 +217,7 @@ const BottomAnchored = styled.div`
 const ContentContainer = styled.div`
   height: 100%;
   width: 100%;
-  padding: 24px 0px;
+  padding: 1.5rem 0;
   display: flex;
   flex-direction: column;
 `;

--- a/src/layout/Menu/examples/SideNav.tsx
+++ b/src/layout/Menu/examples/SideNav.tsx
@@ -1,0 +1,228 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+import { Button } from '../../../components/';
+import { Menu } from '../Menu';
+import { Panel } from '../../Panel/Panel';
+import { Home, Lock } from '../../../icons';
+import { core } from '../../../tokens/';
+
+const StyledPanel = styled(Panel)`
+  ${core.edge(0)};
+  background-color: ${core.color.background(800)};
+`;
+
+const dividerCSS = css`
+  content: '';
+  height: 1px;
+  width: 100%;
+  left: 0;
+  position: absolute;
+  bottom: 0;
+  background-color: ${core.color.stroke};
+`;
+
+export function SideNav() {
+  const folders = (
+    <Menu
+      style={{
+        width: '100%',
+      }}
+      format="basic"
+    >
+      <MenuContainer>
+        <Menu.Item toggle icon={<Home />}>
+          {'Home'}
+          <Menu.Item toggle>
+            {'Product'}
+            <Menu.Item active={true} toggle>
+              {'Panels'}
+              <Menu.Item toggle>
+                {'November 2020'}
+                <Menu.Item toggle>
+                  {'rough cuts'}
+                  <Menu.Item toggle>{'clips'}</Menu.Item>
+                </Menu.Item>
+              </Menu.Item>
+              <Menu.Item toggle>
+                {'October 2020'}
+                <Menu.Item toggle>{'rough cuts'}</Menu.Item>
+              </Menu.Item>
+            </Menu.Item>
+          </Menu.Item>
+          <Menu.Item toggle>
+            {'Engineering'}
+            <Menu.Item toggle>
+              {'Panels'}
+              <Menu.Item toggle>
+                {'November 2020'}
+                <Menu.Item toggle>
+                  {'rough cuts'}
+                  <Menu.Item toggle>{'clips'}</Menu.Item>
+                </Menu.Item>
+              </Menu.Item>
+              <Menu.Item toggle>
+                {'October 2020'}
+                <Menu.Item toggle>{'rough cuts'}</Menu.Item>
+              </Menu.Item>
+            </Menu.Item>
+          </Menu.Item>
+          <Menu.Item toggle>
+            {'Marketing'}
+            <Menu.Item toggle>
+              {'Panels'}
+              <Menu.Item toggle>
+                {'November 2020'}
+                <Menu.Item toggle>
+                  {'rough cuts'}
+                  <Menu.Item toggle>{'clips'}</Menu.Item>
+                </Menu.Item>
+              </Menu.Item>
+              <Menu.Item toggle>
+                {'October 2020'}
+                <Menu.Item toggle>{'rough cuts'}</Menu.Item>
+              </Menu.Item>
+            </Menu.Item>
+          </Menu.Item>
+
+          <Menu.Item toggle>
+            {'Sales'}
+            <Menu.Item toggle>
+              {'Panels'}
+              <Menu.Item toggle>
+                {'November 2020'}
+                <Menu.Item toggle>
+                  {'rough cuts'}
+                  <Menu.Item toggle>{'clips'}</Menu.Item>
+                </Menu.Item>
+              </Menu.Item>
+              <Menu.Item toggle>
+                {'October 2020'}
+                <Menu.Item toggle>{'rough cuts'}</Menu.Item>
+              </Menu.Item>
+            </Menu.Item>
+          </Menu.Item>
+
+          <Menu.Item toggle>
+            {'IT'}
+            <Menu.Item toggle>
+              {'Panels'}
+              <Menu.Item toggle>
+                {'November 2020'}
+                <Menu.Item toggle>
+                  {'rough cuts'}
+                  <Menu.Item toggle>{'clips'}</Menu.Item>
+                </Menu.Item>
+              </Menu.Item>
+              <Menu.Item toggle>
+                {'October 2020'}
+                <Menu.Item toggle>{'rough cuts'}</Menu.Item>
+              </Menu.Item>
+            </Menu.Item>
+          </Menu.Item>
+
+          <Menu.Item>{'Onboarding'}</Menu.Item>
+
+          <Menu.Item toggle>{'Leagal'}</Menu.Item>
+
+          <Menu.Item>{'All Hands'}</Menu.Item>
+
+          <Menu.Item toggle>{'Archived'}</Menu.Item>
+        </Menu.Item>
+      </MenuContainer>
+
+      <MenuContainer>
+        <Menu.Item toggle icon={<Lock />}>
+          {'Private to me'}
+          <Menu.Item>{'WIP'}</Menu.Item>
+          <Menu.Item>{'Recordings'}</Menu.Item>
+          <Menu.Item toggle>
+            {'Drafts'}
+            <Menu.Item>{'Subfolder'}</Menu.Item>
+          </Menu.Item>
+
+          <Menu.Item toggle>
+            {'Meetings'}
+            <Menu.Item>{'Subfolder'}</Menu.Item>
+          </Menu.Item>
+          <Menu.Item toggle>
+            {'Machinations'}
+            <Menu.Item>{'Subfolder'}</Menu.Item>
+          </Menu.Item>
+        </Menu.Item>
+      </MenuContainer>
+    </Menu>
+  );
+
+  const content = (
+    <ContentContainer>
+      <TopAnchored>
+        <Button fluid format="secondary">
+          {'Manage Videos'}
+        </Button>
+      </TopAnchored>
+      <FoldersContainer>{folders}</FoldersContainer>
+      <BottomAnchored>
+        <Button fluid format="secondary">
+          {'Manage Team'}
+        </Button>
+      </BottomAnchored>
+    </ContentContainer>
+  );
+
+  return (
+    <StyledPanel
+      active={true}
+      attach="left"
+      screen={false}
+      content={content}
+    />
+  );
+}
+
+const MenuContainer = styled.div`
+  padding: 16px 0;
+  position: relative;
+  &:not(:only-child):after {
+    content: '';
+    height: 1px;
+    width: 100%;
+    position: absolute;
+    bottom: 0px;
+    background-color: ${core.color.stroke};
+  }
+`;
+
+const TopAnchored = styled.div`
+  flex-shrink: 0;
+  padding: 0 16px 16px 16px;
+  position: relative;
+  &:after {
+    ${dividerCSS};
+    width: 100%;
+  }
+`;
+
+const BottomAnchored = styled.div`
+  position: relative;
+  flex-shrink: 0;
+  padding: 16px 16px 0 16px;
+  &:before {
+    ${dividerCSS};
+    top: 0;
+    width: 100%;
+  }
+`;
+
+const ContentContainer = styled.div`
+  height: 100%;
+  width: 100%;
+  padding: 24px 0px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const FoldersContainer = styled.div`
+  flex-grow: 1;
+  overflow-x: scroll;
+`;

--- a/src/layout/Menu/examples/examples.story.tsx
+++ b/src/layout/Menu/examples/examples.story.tsx
@@ -1,0 +1,4 @@
+export default { title: 'layout/Menu/examples' };
+
+export { recursive } from './recursive';
+export { recursiveWithVideos } from './recursiveWithVideos';

--- a/src/layout/Menu/examples/examples.story.tsx
+++ b/src/layout/Menu/examples/examples.story.tsx
@@ -2,3 +2,5 @@ export default { title: 'layout/Menu/examples' };
 
 export { recursive } from './recursive';
 export { recursiveWithVideos } from './recursiveWithVideos';
+export { Variations } from './variations';
+export { SideNav } from './SideNav';

--- a/src/layout/Menu/examples/recursive.tsx
+++ b/src/layout/Menu/examples/recursive.tsx
@@ -11,22 +11,22 @@ export function recursive() {
         <Menu.Section title="Section 1">
           <Menu.Item icon={<Home />}>Home</Menu.Item>
           <Menu.Item toggle icon={<VideoStack />}>
-            {'Videos'}
+            Videos
             <Menu.Item toggle icon={<Folder />}>
-              {'Panels'}
+              Panels
               <Menu.Item toggle icon={<Folder />}>
-                {'November 2020'}
+                November 2020
                 <Menu.Item toggle icon={<Folder />}>
-                  {'rough cuts'}
+                  rough cuts
                   <Menu.Item toggle icon={<Folder />}>
-                    {'clips'}
+                    clips
                   </Menu.Item>
                 </Menu.Item>
               </Menu.Item>
               <Menu.Item toggle icon={<Folder />}>
-                {'October 2020'}
+                October 2020
                 <Menu.Item toggle icon={<Folder />}>
-                  {'rough cuts'}
+                  rough cuts
                 </Menu.Item>
               </Menu.Item>
             </Menu.Item>

--- a/src/layout/Menu/examples/recursive.tsx
+++ b/src/layout/Menu/examples/recursive.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Menu } from '../Menu';
+
+import { Layout } from '../../../storybook';
+import { Folder, Home, Camera, VideoStack } from '../../../icons';
+
+export function recursive() {
+  return (
+    <Layout.StoryVertical>
+      <Menu style={{ padding: '1rem' }}>
+        <Menu.Section title="Section 1">
+          <Menu.Item icon={<Home />}>Home</Menu.Item>
+          <Menu.Item toggle icon={<VideoStack />}>
+            {'Videos'}
+            <Menu.Item toggle icon={<Folder />}>
+              {'Panels'}
+              <Menu.Item toggle icon={<Folder />}>
+                {'November 2020'}
+                <Menu.Item toggle icon={<Folder />}>
+                  {'rough cuts'}
+                  <Menu.Item toggle icon={<Folder />}>
+                    {'clips'}
+                  </Menu.Item>
+                </Menu.Item>
+              </Menu.Item>
+              <Menu.Item toggle icon={<Folder />}>
+                {'October 2020'}
+                <Menu.Item toggle icon={<Folder />}>
+                  {'rough cuts'}
+                </Menu.Item>
+              </Menu.Item>
+            </Menu.Item>
+          </Menu.Item>
+          <Menu.Item icon={<Camera />}>Live Events</Menu.Item>
+        </Menu.Section>
+      </Menu>
+    </Layout.StoryVertical>
+  );
+}

--- a/src/layout/Menu/examples/recursiveWithVideos.tsx
+++ b/src/layout/Menu/examples/recursiveWithVideos.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Menu } from '../Menu';
+
+import { Layout } from '../../../storybook';
+import {
+  Folder,
+  Home,
+  Camera,
+  VideoStack,
+  Play,
+} from '../../../icons';
+
+export function recursiveWithVideos() {
+  return (
+    <Layout.StoryVertical>
+      <Menu style={{ padding: '1rem' }}>
+        <Menu.Section title="Section 1">
+          <Menu.Item icon={<Home />}>Home</Menu.Item>
+          <Menu.Item toggle icon={<VideoStack />}>
+            {'Videos'}
+            <Menu.Item icon={<Play />}>Video 1</Menu.Item>
+            <Menu.Item icon={<Play />}>Video 2</Menu.Item>
+            <Menu.Item toggle icon={<Folder />}>
+              {'Panels'}
+              <Menu.Item icon={<Play />}>Video 1</Menu.Item>
+              <Menu.Item toggle icon={<Folder />}>
+                {'November 2020'}
+                <Menu.Item icon={<Play />}>Video 1</Menu.Item>
+                <Menu.Item toggle icon={<Folder />}>
+                  {'rough cuts'}
+                  <Menu.Item icon={<Play />}>Video 1</Menu.Item>
+                  <Menu.Item icon={<Play />}>Video 2</Menu.Item>
+                  <Menu.Item icon={<Play />}>Video 3</Menu.Item>
+                  <Menu.Item toggle icon={<Folder />}>
+                    {'clips'}
+                    <Menu.Item icon={<Play />}>Clip 1</Menu.Item>
+                  </Menu.Item>
+                </Menu.Item>
+              </Menu.Item>
+              <Menu.Item toggle icon={<Folder />}>
+                {'October 2020'}
+                <Menu.Item icon={<Play />}>Video 1</Menu.Item>
+                <Menu.Item icon={<Play />}>Video 2</Menu.Item>
+                <Menu.Item toggle icon={<Folder />}>
+                  {'rough cuts'}
+                  <Menu.Item icon={<Play />}>Video 1</Menu.Item>
+                </Menu.Item>
+              </Menu.Item>
+            </Menu.Item>
+          </Menu.Item>
+          <Menu.Item icon={<Camera />}>Live Events</Menu.Item>
+        </Menu.Section>
+      </Menu>
+    </Layout.StoryVertical>
+  );
+}

--- a/src/layout/Menu/examples/recursiveWithVideos.tsx
+++ b/src/layout/Menu/examples/recursiveWithVideos.tsx
@@ -13,36 +13,36 @@ import {
 export function recursiveWithVideos() {
   return (
     <Layout.StoryVertical>
-      <Menu style={{ padding: '1rem' }}>
+      <Menu style={{ padding: '2rem' }}>
         <Menu.Section title="Section 1">
           <Menu.Item icon={<Home />}>Home</Menu.Item>
           <Menu.Item toggle icon={<VideoStack />}>
-            {'Videos'}
+            Videos
             <Menu.Item icon={<Play />}>Video 1</Menu.Item>
             <Menu.Item icon={<Play />}>Video 2</Menu.Item>
             <Menu.Item toggle icon={<Folder />}>
-              {'Panels'}
+              Panels
               <Menu.Item icon={<Play />}>Video 1</Menu.Item>
               <Menu.Item toggle icon={<Folder />}>
-                {'November 2020'}
+                November 2020
                 <Menu.Item icon={<Play />}>Video 1</Menu.Item>
                 <Menu.Item toggle icon={<Folder />}>
-                  {'rough cuts'}
+                  rough cuts
                   <Menu.Item icon={<Play />}>Video 1</Menu.Item>
                   <Menu.Item icon={<Play />}>Video 2</Menu.Item>
                   <Menu.Item icon={<Play />}>Video 3</Menu.Item>
                   <Menu.Item toggle icon={<Folder />}>
-                    {'clips'}
+                    clips
                     <Menu.Item icon={<Play />}>Clip 1</Menu.Item>
                   </Menu.Item>
                 </Menu.Item>
               </Menu.Item>
               <Menu.Item toggle icon={<Folder />}>
-                {'October 2020'}
+                October 2020
                 <Menu.Item icon={<Play />}>Video 1</Menu.Item>
                 <Menu.Item icon={<Play />}>Video 2</Menu.Item>
                 <Menu.Item toggle icon={<Folder />}>
-                  {'rough cuts'}
+                  rough cuts
                   <Menu.Item icon={<Play />}>Video 1</Menu.Item>
                 </Menu.Item>
               </Menu.Item>

--- a/src/layout/Menu/examples/variations.tsx
+++ b/src/layout/Menu/examples/variations.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Menu } from '../Menu';
+import { CirclePlus, Folder } from '../../../icons';
+
+const StoryWrapper = styled.div`
+  width: 250px;
+`;
+
+const longCopy = 'This is how the component handles very long titles';
+const shortCopy = 'My Folders';
+
+export function Variations() {
+  return (
+    <StoryWrapper>
+      <Menu style={{ width: '100%' }} format="basic">
+        <Menu.Section title="Basic">
+          <Menu.Item>{shortCopy}</Menu.Item>
+          <Menu.Item>{longCopy}</Menu.Item>
+          <Menu.Item toggle>{shortCopy}</Menu.Item>
+          <Menu.Item toggle>{longCopy}</Menu.Item>
+          <Menu.Item icon={<Folder />}>{shortCopy}</Menu.Item>
+          <Menu.Item icon={<Folder />}>{longCopy}</Menu.Item>
+          <Menu.Item icon={<Folder />} toggle>
+            {shortCopy}
+          </Menu.Item>
+          <Menu.Item icon={<Folder />} toggle>
+            {longCopy}
+          </Menu.Item>
+
+          <Menu.Item
+            action={{
+              icon: <CirclePlus />,
+              onClick: (e) => console.log(e),
+            }}
+          >
+            {shortCopy}
+          </Menu.Item>
+          <Menu.Item
+            action={{
+              icon: <CirclePlus />,
+              onClick: (e) => console.log(e),
+            }}
+          >
+            {longCopy}
+          </Menu.Item>
+
+          <Menu.Item
+            action={{
+              icon: <CirclePlus />,
+              onClick: (e) => console.log(e),
+            }}
+            icon={<Folder />}
+            toggle
+          >
+            {shortCopy}
+          </Menu.Item>
+          <Menu.Item
+            action={{
+              icon: <CirclePlus />,
+              onClick: (e) => console.log(e),
+            }}
+            icon={<Folder />}
+            toggle
+          >
+            {longCopy}
+          </Menu.Item>
+        </Menu.Section>
+      </Menu>
+    </StoryWrapper>
+  );
+}


### PR DESCRIPTION
### 📚 [`recursive-menu-updates` story](https://vimeo.github.io/iris/sb/recursive-menu-updates/?path=/story/layout-menu-examples--side-nav)

### Description
Adds support for deeply nested menu items and adds some style / behavior updates to the `Menu.Item` component.

Changes:
- Support for deeply nested menus.
- Style updates for `Menu.Item`.
- Truncates text if it would go onto next line.
- Toggle is now it's own button. Sub-menu will only be expanded if toggle is clicked.

### Comments
Branched off of https://github.com/vimeo/iris/tree/recursive-menu.

### Meta


**_Stakeholders:_** @Vimeo/design-systems-core

# Screenshots

Old Behavior: 
![old-menu-click](https://user-images.githubusercontent.com/15743757/130675013-18ababe8-c0c0-429a-840e-61b8dc40d8b2.gif)

New Behavior: 
![new-menu-click](https://user-images.githubusercontent.com/15743757/130675027-2bcdcff2-e9c1-4a91-bcee-df9235ec4ecd.gif)

Old Style:
<img width="317" alt="Screen Shot 2021-08-24 at 3 04 25 PM" src="https://user-images.githubusercontent.com/15743757/130675077-4928c35c-75ab-40d3-8c7a-357fa6b5562a.png">

New Style:
<img width="316" alt="Screen Shot 2021-08-24 at 3 04 53 PM" src="https://user-images.githubusercontent.com/15743757/130675088-022b26ea-7669-4994-b992-81accf1e8d2e.png">
<img width="307" alt="Screen Shot 2021-08-24 at 3 04 59 PM" src="https://user-images.githubusercontent.com/15743757/130675090-430a5b3e-cf68-4fd7-b53c-24af8d7c3359.png">
<img width="303" alt="Screen Shot 2021-08-24 at 3 05 05 PM" src="https://user-images.githubusercontent.com/15743757/130675093-02f2e669-9c24-42a9-bfb7-60718d2bbfda.png">