### PR TITLE
Icons: add Team icon

### DIFF
--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -153,6 +153,7 @@ export { StarFilled } from './ui/StarFilled';
 export { Stats } from './ui/Stats';
 export { Tag } from './ui/Tag';
 export { TagFilled } from './ui/TagFilled';
+export { Team } from './ui/Team';
 export { Television } from './ui/Television';
 export { Trash } from './ui/Trash';
 export { UploadCloud } from './ui/UploadCloud';

--- a/src/icons/ui/Team.tsx
+++ b/src/icons/ui/Team.tsx
@@ -1,0 +1,28 @@
+import React, { forwardRef, Ref, SVGAttributes } from 'react';
+
+export const Team = forwardRef(
+  (props: SVGAttributes<SVGSVGElement>, ref: Ref<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" ref={ref} {...props}>
+      <path
+        d="M20.9992 19.1053H10.5781V14.5264C10.5781 12.8695 11.9213 11.5264 13.5781 11.5264H17.9992C19.656 11.5264 20.9992 12.8695 20.9992 14.5264V19.1053Z"
+        stroke-width="2"
+      />
+      <circle
+        cx="15.7905"
+        cy="7.26316"
+        r="3.26316"
+        stroke-width="2"
+      />
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M6.63322 10.4753C7.89767 10.4753 8.9227 9.43802 8.9227 8.15853C8.9227 6.87903 7.89767 5.8418 6.63322 5.8418C5.36878 5.8418 4.34375 6.87903 4.34375 8.15853C4.34375 9.43802 5.36878 10.4753 6.63322 10.4753Z"
+        stroke-width="2"
+      />
+      <path
+        d="M9.63158 13.5259V16.7364H3V13.5259C3 12.4213 3.89543 11.5259 5 11.5259H7.63158C8.73615 11.5259 9.63158 12.4213 9.63158 13.5259Z"
+        stroke-width="2"
+      />
+    </svg>
+  )
+);

--- a/src/icons/ui/index.ts
+++ b/src/icons/ui/index.ts
@@ -104,6 +104,7 @@ export { StarFilled } from './StarFilled';
 export { Stats } from './Stats';
 export { Tag } from './Tag';
 export { TagFilled } from './TagFilled';
+export { Team } from './Team';
 export { Television } from './Television';
 export { Trash } from './Trash';
 export { UploadCloud } from './UploadCloud';

--- a/src/utils/HOCs/withIris.ts
+++ b/src/utils/HOCs/withIris.ts
@@ -19,12 +19,14 @@ type IrisMeta =
       dev: unknown;
     };
 
-export type IrisComponent<DOMElement, Props> =
-  ForwardRefExoticComponent<
-    PropsWithoutRef<Props> & RefAttributes<DOMElement>
-  > & {
-    $$iris: IrisMeta;
-  };
+export type IrisComponent<
+  DOMElement,
+  Props
+> = ForwardRefExoticComponent<
+  PropsWithoutRef<Props> & RefAttributes<DOMElement>
+> & {
+  $$iris: IrisMeta;
+};
 
 export function withIris<
   DOMElement,
@@ -89,7 +91,7 @@ export function withIris<
       }),
     };
 
-    return RefComponentWithIris as unknown as IrisComponent<
+    return (RefComponentWithIris as unknown) as IrisComponent<
       DOMElement,
       Props
     > &


### PR DESCRIPTION
# Details
### 📚 [`add-team-icon` story](https://github.vimeows.com/pages/vimeo/sb/iris/add-team-icon)

### Description
Adding a new new icon for teams.

### Comments
Also ran prettier on `src/utils/HOCs/withIris.ts` which is unrelated but was failing my build.

### Meta


**_Stakeholders:_** @Vimeo/design-systems-core

# Screenshots
Icon in SB. It's actually supposed to be the opposite (no fill and black stroke) but I think that's just a result of how the story is set up.
<img width="594" alt="Screen Shot 2021-08-27 at 1 20 20 PM" src="https://user-images.githubusercontent.com/15743757/131165254-833f6daf-379d-4559-ba21-d182c3963629.png">
