### PR TITLE
Link to Storybook from within README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@
 
 ## [Iris](https://github.com/vimeo/iris/) is the design system that powers Vimeo's web apps.
 
-Iris provides several reusable components, which are used throughout Vimeo's CMS. You can view the available components in [Storybook](https://vimeo.github.io/iris/sb/main).
+Many components and tokens are viewable in [Storybook](https://vimeo.github.io/iris/sb/main). A documentation website with more comprehensive information, as well as pattern guidance beyond tokens and components is forthcoming.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@
 ```
 
 ## [Iris](https://github.com/vimeo/iris/) is the design system that powers Vimeo's web apps.
+
+Iris provides several reusable components, which are used throughout Vimeo's CMS. You can view the available components in [Storybook](https://vimeo.github.io/iris/sb/main).


### PR DESCRIPTION
Hi there! 👋🏽 

I recently joined the Vimeo OTT Storefront team and was introduced to Iris while pairing with another engineer! We were poking around on the repo and trying to find the actual link to where we would view the available components that we could use, but were struggling to find the right URL.

I ended up finding the link to Storybook through the [Notion wiki](https://www.notion.so/vimeo/Iris-d21f2fc6192247b384a4cc8517aa2c3d), but I figured it might be nice to be able to link to it directly from the README so that in the future, someone else browsing the repo can browse through the components on Storybook more easily. 😃

Hopefully it's okay that I made this PR to add it; let me know if you think it should be worded differently, or if a different change makes more sense.