### PR TITLE
Avoid Proxy usage in motion for IE11 support

### DIFF
--- a/src/components/info/TourPoint/TourPoint.motion.tsx
+++ b/src/components/info/TourPoint/TourPoint.motion.tsx
@@ -1,7 +1,11 @@
 import React, { useMemo } from 'react';
-import { motion } from 'framer-motion';
+import { createDomMotionComponent } from 'framer-motion';
 
 import { generateUID } from '../../../utils';
+
+const motion = {
+  div: createDomMotionComponent('div'),
+};
 
 type Axis = 'X' | 'Y';
 type Invert = -1 | 1;


### PR DESCRIPTION
This PR fixes support for the TourPoint component in IE11, which has issues with Proxy.

Details about the framer motion fix here: https://github.com/framer/motion/pull/781