### PR TITLE
Rename output for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@vimeo/iris",
     "homepage": "https://github.com/vimeo/iris/tree/main",
     "bugs": "https://github.com/vimeo/iris/issues",
-    "version": "0.112.0",
+    "version": "0.112.1",
     "private": false,
     "license": "MIT",
     "description": "Vimeo Design System",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,12 +19,12 @@ export default (args) => {
       {
         dir: 'build',
         format: 'esm',
-        entryFileNames: '[name].mjs',
+        entryFileNames: '[name].esm.js',
       },
       {
         dir: 'build',
         format: 'commonjs',
-        entryFileNames: '[name].cjs',
+        entryFileNames: '[name].js',
       },
     ],
     external: Object.keys(pkg.peerDependencies),

--- a/scripts/add-pkgs
+++ b/scripts/add-pkgs
@@ -11,8 +11,8 @@ let writeFile = util.promisify(fs.writeFile);
 let stat = util.promisify(fs.stat);
 
 const PKG_CONTENTS = `{
-  "main": "./index.cjs",
-  "module": "./index.mjs",
+  "main": "./index.js",
+  "module": "./index.esm.js",
   "sideEffects": false
 }`;
 


### PR DESCRIPTION
This PR renames the outputs of bundles from `.cjs` to `.js` and `.mjs` to `.esm.js` to avoid stricter handling of es modules in webpack builds.