### PR TITLE
Add Dismiss Prop To Sidebar Component

### DIFF
--- a/src/layout/Sidebar/Sidebar.tsx
+++ b/src/layout/Sidebar/Sidebar.tsx
@@ -20,6 +20,7 @@ Sidebar.Break = Break;
 
 function SidebarComponent({
   children,
+  dismiss = true,
   attach = 'left',
   forwardRef,
   onOpen,
@@ -75,13 +76,16 @@ function SidebarComponent({
         {children}
       </SidebarStyled>
       <PanelStyled attach={attach} visible={panel}>
-        <Dismiss
-          aria-label="Dismiss"
-          format="basic"
-          icon={<DismissX />}
-          onClick={close}
-          variant="minimalTransparent"
-        />
+        {dismiss && (
+          <Dismiss
+            aria-label="Dismiss"
+            format="basic"
+            icon={<DismissX />}
+            onClick={close}
+            variant="minimalTransparent"
+          />
+        )}
+        {typeof dismiss === 'function' && dismiss(close)}
         {panel}
       </PanelStyled>
     </div>

--- a/src/layout/Sidebar/Sidebar.tsx
+++ b/src/layout/Sidebar/Sidebar.tsx
@@ -41,6 +41,10 @@ function SidebarComponent({
     return (event) => {
       child.props?.onClick?.(event);
 
+      if (active === child.props.label) {
+        close();
+      }
+
       if (active !== child.props.label) {
         if (active) onClose?.(active);
         onOpen?.(child.props.label);

--- a/src/layout/Sidebar/Sidebar.types.ts
+++ b/src/layout/Sidebar/Sidebar.types.ts
@@ -14,6 +14,7 @@ export type Props = IrisProps<{
    */
   attach?: 'left' | 'right';
   children: ReactElement[];
+  dismiss?: boolean | ((close: VoidFunction) => ReactElement);
   onOpen?: (active: string) => void;
   onClose?: (active: string) => void;
   state?: [string, Dispatch<SetStateAction<string>>];


### PR DESCRIPTION
## What
Adds an optional `dismiss` prop which allows the consumer of the `Sidebar` component to either remove the default `Dismiss` button or provide their own custom `Dismiss` button. 

#### Usage

```tsx
// Render default dismiss button
<Sidebar />

// Hide dismiss button
<Sidebar dismiss={false} />

// Provide custom dismiss button
<Sidebar dismiss={(close: VoidFunction) => <CustomDismissButton onClick={close} />} />
```

## Why
One of the product requirements for the new side navigation component on Single Video is for a user to be able to toggle the sidebar panel by clicking the sidebar icon button. I tried using the setter function that is passed in to the `state` by setting the active panel to an empty string . The issue with this approach is that the panel component is removed from the DOM immediately as opposed to animating to close.

Another requirement is having a custom dismiss button that sits to the left of the panel header. This too was using the same setter logic that was used to toggle the drawer when clicking on the sidebar button. To solve for this we create a new `dismiss` prop that is a function that returns a `ReactElement` and the first argument is the function to `close` the drawer.

**Panel removed immediately when clicking dismiss button**
![side-navigation](https://user-images.githubusercontent.com/77157695/141321747-8cd23330-ca78-4076-b33f-cb39d9201bc5.gif)





#### Todo
- [ ] Create Storybook examples