### PR TITLE
Support preact

### DIFF
--- a/src/components/buttons/Social/SocialButton.style.ts
+++ b/src/components/buttons/Social/SocialButton.style.ts
@@ -28,7 +28,7 @@ export const brandThemes = {
   google: {
     ...themes.light,
     name: 'Google',
-    icon: (GoogleGColor as any).render(),
+    icon: (GoogleGColor as any).render({}),
     formats: {
       ...themes.light.formats,
       primary: '#4285f4',
@@ -38,7 +38,7 @@ export const brandThemes = {
   facebook: {
     ...themes.light,
     name: 'Facebook',
-    icon: (Facebook as any).render(),
+    icon: (Facebook as any).render({}),
     formats: {
       ...themes.light.formats,
       primary: '#4267b2',
@@ -58,7 +58,7 @@ export const brandThemes = {
     light: {
       ...themes.dark,
       name: 'Apple',
-      icon: (Apple as any).render(),
+      icon: (Apple as any).render({}),
       formats: {
         ...themes.dark.formats,
         primary: '#000',
@@ -68,7 +68,7 @@ export const brandThemes = {
     dark: {
       ...themes.light,
       name: 'Apple',
-      icon: (Apple as any).render(),
+      icon: (Apple as any).render({}),
       formats: {
         ...themes.dark.formats,
         primary: '#FFF',

--- a/src/utils/HOCs/withIris.ts
+++ b/src/utils/HOCs/withIris.ts
@@ -66,9 +66,8 @@ export function withIris<
     const component = name?.replace('Component', '');
     const dev = { path, debug };
 
-    const RefComponentWithIris = {
-      $$iris: { version, component, dev },
-      ...forwardRef<DOMElement, Props>((props: any, ref) => {
+    const RefComponentWithIris = forwardRef<DOMElement, Props>(
+      (props: any, ref) => {
         useEffect(() => {
           if (debug || (props && props.debug)) {
             if (ref) console.log({ Component, ref });
@@ -86,8 +85,10 @@ export function withIris<
           forwardRef: ref,
           ...props,
         });
-      }),
-    };
+      }
+    );
+
+    RefComponentWithIris['$$iris'] = { version, component, dev };
 
     return RefComponentWithIris as unknown as IrisComponent<
       DOMElement,
@@ -111,7 +112,7 @@ const soPretty = `
   padding: 0.25rem 1.25rem 0.3rem 0.5rem;
   color: white;
   text-shadow:
-  -1px -1px 0 rgba(0,0,0,0.334),  
+  -1px -1px 0 rgba(0,0,0,0.334),
   1px -1px 0 rgba(0,0,0,0.334),
   -1px 2px 5px rgba(0,0,0,0.334),
   1px 2px 5px rgba(0,0,0,0.334);

--- a/src/utils/hooks/usePortal_DEPRECATED/Anchor.tsx
+++ b/src/utils/hooks/usePortal_DEPRECATED/Anchor.tsx
@@ -103,7 +103,7 @@ export function Anchor({
 }
 
 function useChildZIndex(children) {
-  if (children.ref.current) {
+  if (children?.ref?.current) {
     const style = getComputedStyle(children.ref.current);
     const zIndex = parseInt(style.zIndex);
 


### PR DESCRIPTION
### What
While testing Iris with [Preact](https://github.com/preactjs/preact), we discovered several incompatibilities that prevented proper rendering of Iris components. We've made the necessary adjustments to the Iris source to support Preact. I was able to test the entire Iris Storybook with Preact and there did not appear to be any regressions in functionality across components, but this should be verified with QA before merging. 

### Why
We're working on an update to Vimeo Player UI framework and are considering using Preact. One of the goals for the update is to incorporate Iris components in to the Vimeo player. Given that React and React-DOM are fairly large, we wanted to use Preact instead because of it's fast rendering and small library size. 