### PR TITLE
Notice padding right depends on `onClose` prop

### DIFF
--- a/src/components/info/Notice/Notice.style.ts
+++ b/src/components/info/Notice/Notice.style.ts
@@ -5,11 +5,13 @@ import { rgba, rem } from 'polished';
 import { IrisTheme } from '../../../themes';
 import { Text } from '../../../typography';
 import { core } from '../../../tokens';
+import { onClose } from '../../../utils';
 
 interface Props {
   format?: 'primary' | 'positive' | 'negative';
   header?: string;
   icon?: ReactNode;
+  onClose?: onClose;
   pill?: boolean;
   theme: IrisTheme;
 }
@@ -38,15 +40,16 @@ export const NoticeChildren = styled(Text)`
   color: white;
 `;
 
-function padding({ icon = null, pill = null }) {
+function padding({ icon = null, onClose = null, pill = null }) {
   const pillPad = pill ? 1.5 : 1;
   const iconPad = icon ? 2 : 0;
+  const dismissPad = onClose ? 2.25 : 0;
 
   return {
     paddingTop: '0.75rem',
-    paddingRight: 3 + pillPad + 'rem',
+    paddingRight: pillPad + dismissPad + 'rem',
     paddingBottom: '0.75rem',
-    paddingLeft: 0 + pillPad + iconPad + 'rem',
+    paddingLeft: pillPad + iconPad + 'rem',
   };
 }
 

--- a/src/components/info/Notice/Notice.tsx
+++ b/src/components/info/Notice/Notice.tsx
@@ -64,6 +64,7 @@ function NoticeComponent({
     <NoticeStyled
       format={format}
       icon={icon}
+      onClose={onClose}
       pill={pill}
       ref={forwardRef}
       {...props}


### PR DESCRIPTION
### Description
This PR changes the `padding-right` on the `Notice` component depending on whether or not it has an `onClose` function, which determines whether or not the dismiss button is included. 

On Slack, 0.75rem was suggested. But then I saw 1rem is already used on the left side if there is no icon. I think 1rem looks a little better. Happy to change though!

### Screenshots
#### Before
<img width="593" alt="Screen Shot 2022-01-04 at 11 49 46 AM" src="https://user-images.githubusercontent.com/47210101/148094136-e2a9390c-5c87-489e-a18f-7422ab9e5530.png">

#### After
<img width="596" alt="Screen Shot 2022-01-04 at 11 49 37 AM" src="https://user-images.githubusercontent.com/47210101/148094154-ba43c4ac-25a5-4091-b1fc-94fb8af289ea.png">
<img width="409" alt="Screen Shot 2022-01-04 at 11 54 26 AM" src="https://user-images.githubusercontent.com/47210101/148094826-0eb7d295-a78f-493a-aa59-c31d14cdd41a.png">
