### PR TITLE
Toggle panel when clicking on sidebar item

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -41,6 +41,10 @@ function SidebarComponent({
     return (event) => {
       child.props?.onClick?.(event);
 
+      if (active === child.props.label) {
+        close();
+      }
+
       if (active !== child.props.label) {
         if (active) onClose?.(active);
         onOpen?.(child.props.label);


### PR DESCRIPTION
## What
Would love some thoughts on this PR. Makes a small update to the `toggle` function in the `Sidebar`. Essentially a user would be able to toggle the panel by clicking the sidebar button. This is behavior needed with the collapsed navigation on SVV. 
( Which can be trigger by visiting the manage page and appending `?sn=true` to the url e.g https://vimeo.com/manage/videos/:videoid?sn=true ).

![Toggle Sidebar Panel-high](https://user-images.githubusercontent.com/77157695/153291178-c35af8fb-6384-4a31-98b7-33f1bd7fa03c.gif)


## How it does that
Checks to see if the current active panel is equal to the label of the button being clicked. If so, we close the panel