### PR TITLE
Hide Sidebar Panel From Being Focusable If Hidden

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -74,7 +74,7 @@ function SidebarComponent({
       <SidebarStyled attach={attach} style={displayStyles} {...props}>
         {children}
       </SidebarStyled>
-      <PanelStyled attach={attach} visible={panel}>
+      <PanelStyled hidden={!active} attach={attach} visible={panel}>
         <Dismiss
           aria-label="Dismiss"
           format="basic"

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -74,8 +74,9 @@ function SidebarComponent({
       <SidebarStyled attach={attach} style={displayStyles} {...props}>
         {children}
       </SidebarStyled>
-      <PanelStyled hidden={!active} attach={attach} visible={panel}>
+      <PanelStyled attach={attach} visible={panel}>
         <Dismiss
+          tabIndex={!active ? -1 : 0}
           aria-label="Dismiss"
           format="basic"
           icon={<DismissX />}


### PR DESCRIPTION
**Storybook:** https://vimeo.github.io/iris/sb/fix-hidden-panel-focus/?path=/story/components-sidebar-props--attach

## What
Hides sidebar panel from being focusable when not active. Currently when the sidebar is attached to the right of the window a user is able to tab through the sidebar items and once they pass the last item in the sidebar, the sidebar panel is focused because it is a sibling element of the sidebar.

**Current Issue**
![Panel Focus When Hidden-high](https://user-images.githubusercontent.com/77157695/154322111-c0e13162-497d-4940-bcc0-663d9c2104d4.gif)


## How it does that?
Adds a `hidden` attribute to `PanelStyled`. If the panel is not active then `hidden` is true.