### PR TITLE
[Optimization] Improvement of useAnchor hook to prevent rare #185 errors of react and optimize it

### DIFF
--- a/src/utils/hooks/useAnchor/useAnchor.story.tsx
+++ b/src/utils/hooks/useAnchor/useAnchor.story.tsx
@@ -51,7 +51,11 @@ const CardBg = styled.div`
 `;
 
 function Card({ attach, attachRef, ...props }) {
-  const { styleAnchor, styleChild } = useAnchor(attachRef, attach);
+  const { styleAnchor, styleChild } = useAnchor(
+    attachRef,
+    attach,
+    true
+  );
   const outlet = createPortalOutlet('iris-portals');
 
   return createPortal(


### PR DESCRIPTION
## Story:
https://vimeo.github.io/iris/sb/bug-safari-react-error-185/?path=/story/utilties-useanchor--common

In most cases works like before, but seems like with new variant tour points do not force page to increase height/width when components exceeds space.

## Why:
 - Trying to optimize general flow of useAnchor hook
 - Trying to get rid of react error 185 (caused by circular updates)

## What is done:
- Memoized throttle on page resizing 
- Memoized anchor styles on every render 
-  Do not recompute anchor rect when it is not active
- Prevent circular effect calls when calling setRect during active page resizing 

## What is done [extended]:
### Memoized throttle
On page resizing  do not call circular/nested use effects on every rect update, just do it on active state change or on mount. Basically memoized callback with simplified useEffect.
 
### Memoized anchor styles on every render 
Do not recompute all the styles all the time, do it only when attach prop changes (memo check is less expensive, especially in scale of 10ths of calls when page is resizing and we have 10ths of anchors)

###  Do not recompute anchor rect when it is not active 
With existing implementation even hidden tours cause us to do rerenders in react. With new implementation just detach listeners if anchor is not active.

### Prevent circular effect calls when calling setRect during active page resizing
In some rare cases I could reproduce in my application issue when complex useEffect dependencies caused circular rendering and error 185. I can reproduce it in production application, but cannot do in story book examples.

## Suggestions / for discussion:
 - Probably we can use 'https://www.npmjs.com/package/resize-observer-polyfill' library. It behaves much better and gives much more responsibility comparing to page resize event. We already use it in vimeo live part and it works much nicer regarding handling of all the page events that trigger resize and are not emitted from window 'resize'.

## Could reproduce also in 'main' branch storybook
Happened when I compared my branch user stories with 'main' branch storybook.
Much easier to reproduce it with safari. Not consistent, but active page resizing / tab changing and resizing can help.

<img width="1729" alt="image" src="https://user-images.githubusercontent.com/18573775/154604765-5b59dada-1e26-426b-857e-2426beb2d3cd.png">

Also can confirm that it started after 31 jan iris update and happens 99% in safari browsers from time to time. Internal app debugging showed me that we do only one tour point render (we do not render inactive state at all) and it occasionally crashes page for safari users. Page refresh usually helps to resolve the issue.