### PR TITLE
Add type property to Button

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -44,6 +44,7 @@ function ButtonComponent({
   status,
   textShift = false,
   theme,
+  type = 'button',
   variant = 'solid',
   ...props
 }: Props) {
@@ -76,6 +77,7 @@ function ButtonComponent({
       size={size}
       textShift={textShift}
       theme={theme}
+      type={type}
       variant={variant}
       {...props}
       // {...irisError}

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -13,6 +13,8 @@ export type DOMElement =
   | HTMLAnchorElement
   | HTMLSpanElement;
 
+export type ButtonTypes = 'button' | 'reset' | 'submit';
+
 type ButtonElements = 'button' | 'span' | 'a';
 type Targets = '_blank' | '_self' | '_parent' | '_top';
 type Fluid = true | false | { min?: number; max?: number };
@@ -84,7 +86,7 @@ export type Props = IrisProps<
     /**
      * HTML Button type property
      */
-    type?: 'button' | 'reset' | 'submit';
+    type?: ButtonTypes;
     /**
      * [default = 'solid']
      */

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -82,6 +82,10 @@ export type Props = IrisProps<
     textShift?: boolean;
     theme?: any;
     /**
+     * HTML Button type property
+     */
+    type?: 'button' | 'reset' | 'submit';
+    /**
      * [default = 'solid']
      */
     variant?: typeof variants[number];


### PR DESCRIPTION
### Description
Adding the type property to the Button component so Iris Buttons can be used inside of forms without having to add custom onClick properties to submit or reset the form. 