### PR TITLE
Do not add default `type` to `Button`

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -44,7 +44,6 @@ function ButtonComponent({
   status,
   textShift = false,
   theme,
-  type = 'button',
   variant = 'solid',
   ...props
 }: Props) {
@@ -77,7 +76,6 @@ function ButtonComponent({
       size={size}
       textShift={textShift}
       theme={theme}
-      type={type}
       variant={variant}
       {...props}
       // {...irisError}


### PR DESCRIPTION
With the latest Iris patch release, `type="button"` was added to all buttons. This could mess up buttons that were relying on the default being "submit" when used in a form. This PR only adds the type property if it is added to the `Button`.

Documentation on button type from Mozilla: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type