### PR TITLE
Account for defaultChecked prop in CheckboxSet

### DIFF
--- a/src/components/inputs/Checkbox/CheckboxSet.props.story.tsx
+++ b/src/components/inputs/Checkbox/CheckboxSet.props.story.tsx
@@ -92,21 +92,33 @@ export function DefaultChecked() {
       <CheckboxSet label="defaultChecked" toggled defaultChecked>
         <Checkbox label="." />
         <Checkbox label="." />
+        <Checkbox
+          label="defaultChecked disabled"
+          defaultChecked
+          disabled
+        />
       </CheckboxSet>
 
       <CheckboxSet label="defaultChecked" toggled defaultChecked>
         <Checkbox label="defaultChecked" defaultChecked />
         <Checkbox label="." />
+        <Checkbox label="disabled" disabled />
       </CheckboxSet>
 
       <CheckboxSet label="defaultChecked" toggled defaultChecked>
         <Checkbox label="defaultChecked" defaultChecked />
         <Checkbox label="defaultChecked" defaultChecked />
+        <Checkbox label="disabled" disabled />
       </CheckboxSet>
 
       <CheckboxSet label="." toggled>
         <Checkbox label="defaultChecked" defaultChecked />
         <Checkbox label="defaultChecked" defaultChecked />
+        <Checkbox
+          label="defaultChecked disabled"
+          defaultChecked
+          disabled
+        />
       </CheckboxSet>
 
       <br />
@@ -137,21 +149,29 @@ export function DefaultChecked() {
       <CheckboxSet label="defaultChecked" coupled defaultChecked>
         <Checkbox label="." />
         <Checkbox label="." />
+        <Checkbox label="disabled" disabled />
       </CheckboxSet>
 
       <CheckboxSet label="." coupled>
         <Checkbox label="defaultChecked" defaultChecked />
         <Checkbox label="." />
+        <Checkbox label="disabled" disabled />
       </CheckboxSet>
 
       <CheckboxSet label="." coupled>
         <Checkbox label="defaultChecked" defaultChecked />
         <Checkbox label="defaultChecked" defaultChecked />
+        <Checkbox
+          label="defaultChecked disabled"
+          defaultChecked
+          disabled
+        />
       </CheckboxSet>
 
       <CheckboxSet label="." coupled>
         <Checkbox label="." />
         <Checkbox label="." />
+        <Checkbox label="disabled" disabled />
       </CheckboxSet>
     </Layout.StoryVertical>
   );

--- a/src/components/inputs/Checkbox/CheckboxSet.props.story.tsx
+++ b/src/components/inputs/Checkbox/CheckboxSet.props.story.tsx
@@ -63,6 +63,29 @@ export function Toggled() {
   );
 }
 
+export function DefaultChecked() {
+  return (
+    <Layout.StoryVertical>
+      <Header size="5">
+        This `toggled` checkbox is default checked. Its children can
+        be checked or unchecked by default.
+      </Header>
+      <CheckboxSet label="toggled" toggled defaultChecked>
+        <Checkbox label="default checked" defaultChecked />
+        <Checkbox label="default unchecked" />
+      </CheckboxSet>
+      <Header size="5">
+        This `coupled` checkbox is default checked. Its children are
+        also checked by default.
+      </Header>
+      <CheckboxSet label="coupled" coupled defaultChecked>
+        <Checkbox label="default checked" />
+        <Checkbox label="default checked" />
+      </CheckboxSet>
+    </Layout.StoryVertical>
+  );
+}
+
 export function Disabled() {
   return (
     <CheckboxSet label="disabled" disabled>

--- a/src/components/inputs/Checkbox/CheckboxSet.props.story.tsx
+++ b/src/components/inputs/Checkbox/CheckboxSet.props.story.tsx
@@ -24,6 +24,7 @@ export function Coupled() {
     </Layout.StoryVertical>
   );
 }
+Coupled.storyName = 'coupled';
 
 export function Toggled() {
   const checkboxRef = useRef(null);
@@ -62,29 +63,100 @@ export function Toggled() {
     </Layout.StoryVertical>
   );
 }
+Toggled.storyName = 'toggled';
 
 export function DefaultChecked() {
   return (
     <Layout.StoryVertical>
-      <Header size="5">
-        This `toggled` checkbox is default checked. Its children can
-        be checked or unchecked by default.
+      <Header size="3">Toggled</Header>
+      <Header
+        size="5"
+        style={{
+          paddingLeft: '1.5rem',
+          display: 'block',
+          borderLeft: '2px solid rgba(150,150,150,0.334)',
+        }}
+      >
+        `toggled` variant CheckboxSets will show/hide the children
+        when the parent Checkbox is toggled.
+        <br />
+        <br />
+        The value of the parent does not impact the value of the
+        children.
+        <br />
+        <br />
+        The value of children determines if the parent is `checked` or
+        `indeterminate`.
       </Header>
-      <CheckboxSet label="toggled" toggled defaultChecked>
-        <Checkbox label="default checked" defaultChecked />
-        <Checkbox label="default unchecked" />
+
+      <CheckboxSet label="defaultChecked" toggled defaultChecked>
+        <Checkbox label="." />
+        <Checkbox label="." />
       </CheckboxSet>
-      <Header size="5">
-        This `coupled` checkbox is default checked. Its children are
-        also checked by default.
+
+      <CheckboxSet label="defaultChecked" toggled defaultChecked>
+        <Checkbox label="defaultChecked" defaultChecked />
+        <Checkbox label="." />
+      </CheckboxSet>
+
+      <CheckboxSet label="defaultChecked" toggled defaultChecked>
+        <Checkbox label="defaultChecked" defaultChecked />
+        <Checkbox label="defaultChecked" defaultChecked />
+      </CheckboxSet>
+
+      <CheckboxSet label="." toggled>
+        <Checkbox label="defaultChecked" defaultChecked />
+        <Checkbox label="defaultChecked" defaultChecked />
+      </CheckboxSet>
+
+      <br />
+      <br />
+      <br />
+
+      <Header size="3">Coupled</Header>
+      <Header
+        size="5"
+        style={{
+          paddingLeft: '1.5rem',
+          display: 'block',
+          borderLeft: '2px solid rgba(150,150,150,0.334)',
+        }}
+      >
+        `coupled` variant CheckboxSets will toggle the value of the
+        children when the parent Checkbox is toggled.
+        <br />
+        <br />
+        The value of the parent always impacts the value of the
+        children.
+        <br />
+        <br />
+        The value of children determines if the parent is `unchecked`,
+        `checked`, or `indeterminate`.
       </Header>
-      <CheckboxSet label="coupled" coupled defaultChecked>
-        <Checkbox label="default checked" />
-        <Checkbox label="default checked" />
+
+      <CheckboxSet label="defaultChecked" coupled defaultChecked>
+        <Checkbox label="." />
+        <Checkbox label="." />
+      </CheckboxSet>
+
+      <CheckboxSet label="." coupled>
+        <Checkbox label="defaultChecked" defaultChecked />
+        <Checkbox label="." />
+      </CheckboxSet>
+
+      <CheckboxSet label="." coupled>
+        <Checkbox label="defaultChecked" defaultChecked />
+        <Checkbox label="defaultChecked" defaultChecked />
+      </CheckboxSet>
+
+      <CheckboxSet label="." coupled>
+        <Checkbox label="." />
+        <Checkbox label="." />
       </CheckboxSet>
     </Layout.StoryVertical>
   );
 }
+DefaultChecked.storyName = 'defaultChecked';
 
 export function Disabled() {
   return (
@@ -94,3 +166,4 @@ export function Disabled() {
     </CheckboxSet>
   );
 }
+Disabled.storyName = 'disabled';

--- a/src/components/inputs/Checkbox/CheckboxSet.tsx
+++ b/src/components/inputs/Checkbox/CheckboxSet.tsx
@@ -31,10 +31,28 @@ function CheckboxSetComponent({
   const UID = useMemo(() => gUID(), []);
   const UIDs = useMemo(() => children.map(() => gUID()), [children]);
 
-  const all = (boolean) =>
-    coupled
-      ? children.map(() => boolean)
-      : [...children.map(() => boolean), boolean];
+  function all(boolean: boolean) {
+    if (coupled) {
+      return children.map((child, i) => {
+        if (!child.props.disabled) {
+          return boolean;
+        } else {
+          return checks?.[i] || child.props.defaultChecked;
+        }
+      });
+    } else {
+      return [
+        ...children.map((child, i) => {
+          if (!child.props.disabled) {
+            return boolean;
+          } else {
+            return checks?.[i] || child.props.defaultChecked;
+          }
+        }),
+        boolean,
+      ];
+    }
+  }
 
   const [checks, checksSet] = useState(all(false));
 
@@ -43,7 +61,7 @@ function CheckboxSetComponent({
       ? children.map((child) =>
           typeof defaultChecked === 'undefined'
             ? !!child.props.defaultChecked
-            : !!defaultChecked
+            : !child?.props?.disabled && !!defaultChecked
         )
       : [
           ...children.map((child) => !!child.props.defaultChecked),
@@ -76,8 +94,8 @@ function CheckboxSetComponent({
       id: `checkbox-${i}-${UIDs[i]}`,
       name: UID,
       value: UIDs[i],
-      disabled: disabled,
-      defaultChecked: undefined,
+      disabled: child?.props?.disabled || disabled,
+      defaultChecked: child?.props?.defaultChecked,
       onChange: (e) => {
         checksSet(toggle(i));
         child.props.onChange && child.props.onChange(e);

--- a/src/components/inputs/Checkbox/CheckboxSet.tsx
+++ b/src/components/inputs/Checkbox/CheckboxSet.tsx
@@ -31,6 +31,8 @@ function CheckboxSetComponent({
   const UID = useMemo(() => gUID(), []);
   const UIDs = useMemo(() => children.map(() => gUID()), [children]);
 
+  // Checks for coupled prop and checks for child checkbox disabled state
+  // Returns checked state for children
   function all(boolean: boolean) {
     if (coupled) {
       return children.map((child, i) => {

--- a/src/components/inputs/Checkbox/CheckboxSet.tsx
+++ b/src/components/inputs/Checkbox/CheckboxSet.tsx
@@ -20,6 +20,7 @@ function CheckboxSetComponent({
   toggled,
   onChange,
   disabled,
+  defaultChecked,
   ...props
 }: Props) {
   const UID = useMemo(() => generateUID(), []);
@@ -33,7 +34,18 @@ function CheckboxSetComponent({
       ? children.map(() => boolean)
       : [...children.map(() => boolean), boolean];
 
-  const [checks, setChecks] = useState(all(false));
+  const initialState = coupled
+    ? children.map((child) =>
+        typeof defaultChecked === 'undefined'
+          ? !!child.props.defaultChecked
+          : !!defaultChecked
+      )
+    : [
+        ...children.map((child) => !!child.props.defaultChecked),
+        !!defaultChecked,
+      ];
+
+  const [checks, setChecks] = useState(initialState);
 
   if (
     !validate(children, 'checkbox') &&
@@ -77,6 +89,7 @@ function CheckboxSetComponent({
               name: UID,
               value: UIDs[i],
               disabled: disabled,
+              defaultChecked: undefined,
               onChange: (e) => {
                 setChecks(toggle(i));
                 child.props.onChange && child.props.onChange(e);


### PR DESCRIPTION
## Description
Account for `defaultChecked` in checkboxes initial state when used in CheckboxSet. Currently, the `defaultChecked` is ignored. 

## Desired behavior
**For `coupled` CheckboxSet**
- If `defaultChecked=true` is passed to parent checkbox, then children checkboxes will be checked. 
- If `defaultChecked=false` is passed to parent checkbox, then children checkboxes will be unchecked. 
- If `defaultChecked` is not passed to parent checkbox, then children checkboxes can have their own `defaultChecked` states.

**For `toggled` CheckboxSet**
- If `defaultChecked=true` is passed to parent checkbox, then children checkboxes will be visible. Children checkboxes can have their own `defaultChecked` states
- If `defaultChecked=false` is passed to parent checkbox, or not passed at all, then children checkboxes will be hidden and unchecked by default. 

## Links
[Story](https://vimeo.github.io/iris/sb/checkboxset-defaultchecked/?path=/story/components-checkboxset-props--default-checked)
