### PR TITLE
Forward the name prop to the file input in FileUpload

### DIFF
--- a/src/components/inputs/FileUpload/FileUpload.tsx
+++ b/src/components/inputs/FileUpload/FileUpload.tsx
@@ -18,6 +18,7 @@ function FileUploadComponent({
   disabled,
   accept,
   multiple,
+  name,
   ...props
 }: Props) {
   const ref = useRef(null);
@@ -37,6 +38,7 @@ function FileUploadComponent({
         disabled={disabled}
         onChange={onChange}
         multiple={multiple}
+        name={name}
       ></Hidden>
       {children}
     </div>


### PR DESCRIPTION
### Description
Forwarding the name prop to the hidden file input in FileUpload will allow us to use this component with `react-hook-form` for form state management. 