### PR TITLE
Allow for customizable modal screen overlay color

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -50,6 +50,7 @@ function ModalComponent({
   onClose,
   onOpen,
   screen = true,
+  screenColor,
   ...props
 }: Props) {
   const attach: Attach = feature
@@ -91,6 +92,7 @@ function ModalComponent({
       onClose,
       onOpen,
       screen,
+      screenColor,
     }
   );
 

--- a/src/components/Modal/Modal.types.ts
+++ b/src/components/Modal/Modal.types.ts
@@ -32,6 +32,11 @@ export type Props = IrisProps<
      */
     screen?: boolean;
     /**
+     * Provide a color string for the screen behind the Modal
+     *
+     */
+    screenColor?: string;
+    /**
      * [default = 'md']
      */
     size?: 'sm' | 'md' | 'lg';

--- a/src/utils/hooks/usePortal_DEPRECATED/usePortal_DEPRECATED.style.ts
+++ b/src/utils/hooks/usePortal_DEPRECATED/usePortal_DEPRECATED.style.ts
@@ -5,14 +5,15 @@ const fadeIn = keyframes`
   100% { opacity: 1 }
 `;
 
-export const Screen = styled.div`
+export const Screen = styled.div<{ screenColor?: string }>`
   cursor: pointer;
   position: fixed;
   width: 100%;
   height: 100%;
   top: 0;
   left: 0;
-  background: rgba(50, 50, 50, 0.667);
+  background: ${({ screenColor }) =>
+    screenColor || 'rgba(50, 50, 50, 0.667)'};
   z-index: 1999;
   transition: 200ms;
   animation: ${fadeIn} 150ms ease-in-out;

--- a/src/utils/hooks/usePortal_DEPRECATED/usePortal_DEPRECATED.types.ts
+++ b/src/utils/hooks/usePortal_DEPRECATED/usePortal_DEPRECATED.types.ts
@@ -30,6 +30,7 @@ export interface PortalConfig {
   onClose?: MouseEventHandler;
   onOpen?: MouseEventHandler;
   screen?: boolean;
+  screenColor?: string;
   trigger?: 'click' | 'hover';
 }
 


### PR DESCRIPTION
Our [designs for Replace Video](https://www.figma.com/file/V4GZCHFpwPS6Jdx6p2dMtl/%F0%9F%9A%A7-Single-video-page?node-id=22624%3A261722) have a different color for the screen overlay for the modal. This PR suggests one approach to how to allow that.