### PR TITLE
Add additional error and warning state in withCharacterCount payload

### DIFF
--- a/src/components/inputs/withCharacterCount/withCharacterCount.state.ts
+++ b/src/components/inputs/withCharacterCount/withCharacterCount.state.ts
@@ -4,11 +4,13 @@ export function reducer(state, { type, payload = null }) {
       return {
         ...state,
         error: payload,
+        warning: false,
       };
     case 'SET_WARNING':
       return {
         ...state,
         warning: payload,
+        error: false,
       };
     case 'SET_REMAINING_CHARACTERS':
       return {


### PR DESCRIPTION
Bug: Messaging text at the bottom of the input field remains red even after a user has removed exceeded characters.


https://user-images.githubusercontent.com/22207955/170062875-5be57b57-6c7d-4222-b6f5-89012e001e55.mov

Fix: Toggled off `warning` and `error` state in withCharacterCount reducer.

