### PR TITLE
Visibility hidden for hidden panel to prevent focus of children

### DIFF
--- a/src/components/Panel/Panel.style.ts
+++ b/src/components/Panel/Panel.style.ts
@@ -1,7 +1,16 @@
-import styled, { css } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 import { rgba } from 'polished';
 
 import { blue, white } from '../../color';
+
+const hidden = keyframes`
+  from {
+    visibility: visible;
+  }
+  to {
+    visibility: hidden;
+  }
+`;
 
 export const PanelStyled = styled.div<any>`
   position: absolute;
@@ -12,11 +21,13 @@ export const PanelStyled = styled.div<any>`
   background: ${(p) => p.theme.content.background};
   ${edge};
 
-  will-change: width, transform;
-
   width: var(--width);
   transform: var(--transform);
   transition: var(--transition);
+
+  animation: ${(p) => !p.active && hidden};
+  animation-delay: ${(p) => p.duration};
+  animation-fill-mode: forwards;
 `;
 
 function edge({ theme, attach }) {

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -114,10 +114,10 @@ function PanelComponent({
   const hidden = `translateX(${shift * 100}%)`;
   const transform = active ? visible : hidden;
 
-  const duration = Math.round(width / 6 + 90);
+  const duration = `${Math.round(width / 6 + 90)}ms`;
   const transition = dragging
     ? 'none'
-    : `transform ${duration}ms ease-in-out`;
+    : `transform ${duration} ease-in-out`;
 
   const styleVars = useStyleVars({
     transform,
@@ -132,6 +132,8 @@ function PanelComponent({
       ref={ref}
       style={{ [attach]: 0, ...style, ...styleVars }}
       {...props}
+      active={active}
+      duration={duration}
     >
       {content}
       {handle}


### PR DESCRIPTION
Alternative to https://github.com/vimeo/iris/pull/91

To prevent tab focus from reaching sidebar children when collapsed, this change adds "visibility:hidden" to the hidden sidebar. In order to allow the slide out animation to complete before hiding, the visibility change is done via a delayed animation. The delay corresponds with the slide out time.