### PR TITLE
More flexible react peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,8 +92,8 @@
     "peerDependencies": {
         "@babel/runtime": "^7.18.3",
         "polished": "^4.2.2",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
+        "react": "^16.13.1 || ^17.0.0",
+        "react-dom": "^13.13.1 || ^17.0.0",
         "styled-components": "^5.3.5"
     },
     "resolutions": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "@babel/runtime": "^7.18.3",
         "polished": "^4.2.2",
         "react": "^16.13.1 || ^17.0.0",
-        "react-dom": "^13.13.1 || ^17.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0",
         "styled-components": "^5.3.5"
     },
     "resolutions": {


### PR DESCRIPTION
Context: we're using React 16 in Vimeo OTT. With the newer version of
npm (8.6.0+), `npm install` will fail due to this conflict.

Assuming Iris doesn't currently depend on any React 17+ APIs, perhaps
this is fine.