### PR TITLE
Update icon overflow for small buttons

### DIFF
--- a/src/components/Button/Button.props.story.tsx
+++ b/src/components/Button/Button.props.story.tsx
@@ -16,6 +16,10 @@ import {
   DownloadArrow,
   Plus,
   UploadCloud,
+  Clock,
+  Heart,
+  HeartFilled,
+  PaperPlane,
 } from '../../icons';
 
 export default {
@@ -103,6 +107,17 @@ export function IconPosition() {
   ));
 }
 IconPosition.storyName = 'iconPosition';
+
+export const IconSmall = () => {
+  return (
+    <div>
+      {[Clock, Heart, HeartFilled, PaperPlane].map((Icon, idx) => {
+        return <Button key={idx} size="sm" icon={<Icon />} />;
+      })}
+    </div>
+  );
+};
+IconSmall.storyName = 'icon (small)';
 
 export function Fluid() {
   return <Button fluid>Fluid Button</Button>;

--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -79,6 +79,7 @@ function buttonIcon({ size, iconOnly, iconPosition }) {
           width: ${pad / 1.25 + 0.75}rem;
           height: ${pad / 1.25 + 0.75}rem;
           display: inline-flex;
+          overflow: visible;
 
           > * {
             fill: currentColor;
@@ -97,6 +98,7 @@ function buttonIcon({ size, iconOnly, iconPosition }) {
           margin: ${iconMargin[iconPosition]};
           position: ${iconPosition === 'action' && 'absolute'};
           right: ${iconPosition === 'action' && '0.5rem'};
+          overflow: visible;
 
           > * {
             fill: currentColor;


### PR DESCRIPTION
We recently discovered a minor bug on Safari and Firefox where some icons inside `sm` Buttons are clipped to the bottom and/or right. Some icons that have this happen to them include `Clock`, `Heart`, and `HeartFilled`. This PR:

1. Add `overflow: visible` to SVGs in the Button component to resolve the issue.
2. Adds a Storybook story to render all Icons within `sm` Buttons to be able to detect which icons face this issue.

<img width="856" alt="Screen Shot 2022-06-29 at 11 15 10 AM" src="https://user-images.githubusercontent.com/46363215/176764267-827e6517-6d89-40d5-9dc7-7a723ca1616e.png">
 