### PR TITLE
Add color-scheme in GlobalStyle to match theme name

### DIFF
--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -75,6 +75,11 @@ export const Focus = styled.div<any>`
 const vimeoFont = `'Helvetica Neue', Helvetica, Arial, sans-serif;`;
 
 export const GlobalStyles = createGlobalStyle<{ theme: IrisTheme }>`
+
+  :root {
+    color-scheme: ${({ theme }) => theme.name}
+  }
+
   html {
     box-sizing: border-box;
     padding: 0;


### PR DESCRIPTION
Adds color-scheme to :root in GlobalStyles so scrollbars match theme:

![Screen Shot 2022-07-27 at 12 01 48 PM](https://user-images.githubusercontent.com/22207955/181297668-52df35c8-d601-497e-ba20-39e76e0dc272.png)
![Screen Shot 2022-07-27 at 12 01 57 PM](https://user-images.githubusercontent.com/22207955/181297676-77d29141-ffa8-4330-801b-56d575638efe.png)

