### PR TITLE
Show storybook controls panel by default

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -525,6 +525,8 @@ export const parameters = {
       ],
       locales: '',
     },
+    showPanel: true,
+    panelPosition: 'bottom',
   },
   controls: {
     expanded: true,


### PR DESCRIPTION
Sets the controls panel to show up on the bottom of the story.