### PR TITLE
Adds args to stories for source doc blocks

### DIFF
--- a/src/_labs/Pronouns/Pronouns.story.tsx
+++ b/src/_labs/Pronouns/Pronouns.story.tsx
@@ -24,11 +24,12 @@ const commentVariations = {
   'text below avatar': 'G',
 };
 
-export function Comments() {
+export function Comments({ args }) {
   return (
     <Story title={componentName}>
       {demoProps.map((comment, i) => (
         <Comment
+          {...args}
           key={i}
           name={comment.name}
           id={comment.id}
@@ -45,24 +46,24 @@ export function Comments() {
   );
 }
 
-export function GeneralSettings() {
+export function GeneralSettings({ args }) {
   return (
-    <Story title="Settings">
+    <Story title="Settings" {...args}>
       <AccountSettings />
     </Story>
   );
 }
 
-export function UserSettings() {
+export function UserSettings({ args }) {
   return (
-    <Story title="Settings">
+    <Story title="Settings" {...args}>
       <UserInfo name="Sean McIntyre" badge="staff" id="26000555" />
     </Story>
   );
 }
-export function AutoComplete() {
+export function AutoComplete({ args }) {
   return (
-    <Story title="AutoComplete">
+    <Story title="AutoComplete" {...args}>
       {demoProps
         .filter((user) => !user.name.includes('Vim'))
         .map((comment) => (
@@ -89,9 +90,9 @@ export function AutoComplete() {
   );
 }
 
-export function VideoList() {
+export function VideoList({ args }) {
   return (
-    <Story title="Video List">
+    <Story title="Video List" {...args}>
       <AutoplayList
         videos={staffPicks}
         variation="A"

--- a/src/components/Badge/Badge.props.story.tsx
+++ b/src/components/Badge/Badge.props.story.tsx
@@ -13,18 +13,18 @@ export default {
   },
 };
 
-export function Href() {
+export function Href({ args }) {
   return (
-    <Layout.StoryVertical defaultWidth>
+    <Layout.StoryVertical defaultWidth {...args}>
       <Badge format="upgrade" href="#" />
     </Layout.StoryVertical>
   );
 }
 Href.storyName = 'href';
 
-export function Format() {
+export function Format({ args }) {
   return (
-    <Layout.StoryVertical defaultWidth>
+    <Layout.StoryVertical defaultWidth {...args}>
       <Badge size="xl" format="mature" />
       <Badge size="xl" format="not-yet-rated" />
     </Layout.StoryVertical>
@@ -32,9 +32,9 @@ export function Format() {
 }
 Format.storyName = 'format';
 
-export function Format_OLD() {
+export function Format_OLD({ args }) {
   return (
-    <Layout.StoryVertical defaultWidth>
+    <Layout.StoryVertical defaultWidth {...args}>
       <Badge>default</Badge>
       <Badge format="alum" />
       <Badge format="beta" />
@@ -60,9 +60,9 @@ export function Format_OLD() {
 }
 Format_OLD.storyName = 'format (old)';
 
-export function Size() {
+export function Size({ args }) {
   return (
-    <Layout.StoryVertical defaultWidth>
+    <Layout.StoryVertical defaultWidth {...args}>
       <Badge format="mature" size="sm" />
       <Badge format="mature" size="lg" />
       <Badge format="mature" size="xl" />

--- a/src/components/Button/Button.props.story.tsx
+++ b/src/components/Button/Button.props.story.tsx
@@ -24,6 +24,7 @@ import {
 
 export default {
   title: 'components/Button/props',
+  component: B,
 };
 
 const Button = styled(B)`
@@ -31,14 +32,19 @@ const Button = styled(B)`
   margin: 0 1rem 1rem 0;
 `;
 
-export function Disabled() {
-  return <Button disabled>Button</Button>;
+export function Disabled({ args }) {
+  return (
+    <Button disabled {...args}>
+      Button
+    </Button>
+  );
 }
 Disabled.storyName = 'disabled';
 
-export function Element() {
+export function Element({ args }) {
   return (
     <Button
+      {...args}
       element="a"
       href="#"
       css={`
@@ -51,32 +57,32 @@ export function Element() {
 }
 Element.storyName = 'element';
 
-export function Format() {
+export function Format({ args }) {
   return formats.map((format, i) => (
-    <Button key={i} format={format} children={format} />
+    <Button key={i} format={format} children={format} {...args} />
   ));
 }
 Format.storyName = 'format';
 
-export function Variant() {
+export function Variant({ args }) {
   return variants.map((variant, i) => (
-    <Button key={i} variant={variant} children={variant} />
+    <Button key={i} variant={variant} children={variant} {...args} />
   ));
 }
 Variant.storyName = 'variant';
 
-export function Status() {
+export function Status({ args }) {
   return statuses.map((status, i) => (
-    <Button key={i} status={status} children={status} />
+    <Button key={i} status={status} children={status} {...args} />
   ));
 }
 Status.storyName = 'status';
 
-export function Size() {
+export function Size({ args }) {
   const style = { display: 'inline-flex' };
 
   return sizes.map((size, i) => (
-    <div key={i} style={{ display: 'flex' }}>
+    <div key={i} style={{ display: 'flex' }} {...args}>
       <Button size={size} style={style}>
         Button
       </Button>
@@ -89,45 +95,55 @@ export function Size() {
 }
 Size.storyName = 'size';
 
-export function Icon() {
-  return <Button icon={<DownloadArrow />} />;
+export function Icon({ args }) {
+  return <Button icon={<DownloadArrow {...args} />} />;
 }
 Icon.storyName = 'icon';
 
-export function IconPill() {
-  return <Button icon={<Plus />} pill />;
+export function IconPill({ args }) {
+  return <Button icon={<Plus />} pill {...args} />;
 }
 IconPill.storyName = 'icon, pill';
 
-export function IconPosition() {
+export function IconPosition({ args }) {
   return iconPositions.map((position, i) => (
-    <Button icon={<UploadCloud />} iconPosition={position} key={i}>
+    <Button
+      icon={<UploadCloud />}
+      iconPosition={position}
+      key={i}
+      {...args}
+    >
       iconPosition {position}
     </Button>
   ));
 }
 IconPosition.storyName = 'iconPosition';
 
-export const IconSmall = () => {
+export function IconSmall({ args }) {
   return (
-    <div>
+    <div {...args}>
       {[Clock, Heart, HeartFilled, PaperPlane].map((Icon, idx) => {
         return <Button key={idx} size="sm" icon={<Icon />} />;
       })}
     </div>
   );
-};
+}
 IconSmall.storyName = 'icon (small)';
 
-export function Fluid() {
-  return <Button fluid>Fluid Button</Button>;
+export function Fluid({ args }) {
+  return (
+    <Button fluid {...args}>
+      Fluid Button
+    </Button>
+  );
 }
 Fluid.storyName = 'fluid';
 
-export function FluidVaried() {
+export function FluidVaried({ args }) {
   return (
     <>
       <Button
+        {...args}
         fluid={{ min: 0, max: 500 }}
         children="{ min: 0, max: 500 }"
       />
@@ -160,27 +176,32 @@ export function FluidVaried() {
 }
 FluidVaried.storyName = 'fluid (queried)';
 
-export const Loading = () => <LoadingStory />;
-function LoadingStory() {
+export function LoadingStory({ args }) {
   const [loading, setLoading] = useState(false);
   const onClick = () => setLoading((loading) => !loading);
 
   return (
-    <Button size="lg" loading={!loading} onClick={onClick}>
+    <Button size="lg" loading={!loading} onClick={onClick} {...args}>
       Click Me
     </Button>
   );
 }
+export const Loading = ({ args }) => <LoadingStory {...args} />;
 Loading.storyName = 'loading';
 
-export const Overflow = () => {
-  return <Button overflow>Button</Button>;
-};
+export function Overflow({ args }) {
+  return (
+    <Button overflow {...args}>
+      Button
+    </Button>
+  );
+}
 Overflow.storyName = 'overflow';
 
-export function TextShift() {
+export function TextShift({ args }) {
   return (
     <div
+      {...args}
       style={{
         margin: '1rem auto',
         width: '15rem',
@@ -207,9 +228,9 @@ export function TextShift() {
 }
 TextShift.storyName = 'textShift';
 
-export const CustomColor = () => {
+export function CustomColor({ args }) {
   return (
-    <div>
+    <div {...args}>
       <Button color="#07796a">Button</Button>
       <Button variant="minimal" color="#aa91e5">
         Button
@@ -245,5 +266,5 @@ export const CustomColor = () => {
       </Button>
     </div>
   );
-};
+}
 CustomColor.storyName = 'color';

--- a/src/components/Button/examples/Growth.story.tsx
+++ b/src/components/Button/examples/Growth.story.tsx
@@ -10,9 +10,9 @@ export default {
   component: B,
 };
 
-export function GrowthCTA() {
+export function GrowthCTA({ args }) {
   return (
-    <div>
+    <div {...args}>
       <Button size="xl" icon={<UploadCloud />}>
         Create videos
       </Button>

--- a/src/components/ButtonSocial/ButtonSocial.story.tsx
+++ b/src/components/ButtonSocial/ButtonSocial.story.tsx
@@ -13,10 +13,10 @@ const ButtonSocial = styled(SB)`
   margin: 0 1rem 1rem 0;
 `;
 
-export function Social() {
+export function Social({ args }) {
   return (
     <>
-      <ButtonSocial brand="apple" fluid>
+      <ButtonSocial brand="apple" fluid {...args}>
         Sign in with Apple
       </ButtonSocial>
       <ButtonSocial brand="facebook" fluid>

--- a/src/components/ButtonToggleState/ButtonToggleState.story.tsx
+++ b/src/components/ButtonToggleState/ButtonToggleState.story.tsx
@@ -15,14 +15,14 @@ export default {
   component: B,
 };
 
-export const ButtonToggleStateStory = () => <CommonStory />;
-function CommonStory() {
+export function ButtonToggleStateStory({ args }) {
   const [following, setFollowing] = useState(false);
   const toggleFollowing = () =>
     setFollowing((following) => !following);
 
   return (
     <ButtonToggleState
+      {...args}
       variant="solid"
       isActive={following}
       onClick={toggleFollowing}
@@ -35,15 +35,14 @@ function CommonStory() {
     />
   );
 }
-ButtonToggleStateStory.storyName = 'ButtonToggleStateStory';
 
-export const AllStates = () => <AllStatesStory />;
-function AllStatesStory() {
+export function AllStatesStory({ args }) {
   return (
     <>
       {/** Primary format, inactive state */}
       <Header size="6">Inactive</Header>
       <ButtonToggleState
+        {...args}
         variant="solid"
         isActive={false}
         offStateText="Follow"
@@ -83,8 +82,7 @@ function AllStatesStory() {
   );
 }
 
-export const Format = () => <FormatStory />;
-function FormatStory() {
+export function FormatStory({ args }) {
   const [following, setFollowing] = useState(false);
   const toggleFollowing = () =>
     setFollowing((following) => !following);
@@ -92,6 +90,7 @@ function FormatStory() {
   return (
     <>
       <ButtonToggleState
+        {...args}
         variant="solid"
         isActive={following}
         onClick={toggleFollowing}

--- a/src/components/CardNewItem/examples/VideoLibrary.story.tsx
+++ b/src/components/CardNewItem/examples/VideoLibrary.story.tsx
@@ -12,9 +12,9 @@ export default {
   component: CardNewItem,
 };
 
-export function VideoLibrary() {
+export function VideoLibrary({ args }) {
   return (
-    <Layout.FullBleed style={{ display: 'block' }}>
+    <Layout.FullBleed style={{ display: 'block' }} {...args}>
       <Mast>
         <Header size="plusUltra">Header</Header>
       </Mast>

--- a/src/components/CounterIcon/CounterIcon.story.tsx
+++ b/src/components/CounterIcon/CounterIcon.story.tsx
@@ -10,10 +10,10 @@ export default {
   component: CounterIcon,
 };
 
-export function CounterIconStory() {
+export function CounterIconStory({ args }) {
   return (
     <Layout.StoryVertical>
-      <CounterIcon icon={<Play />} title="Download Count">
+      <CounterIcon icon={<Play />} title="Download Count" {...args}>
         2.12K
       </CounterIcon>
       <CounterIcon icon={<Collections />} title="Play Count">

--- a/src/components/LoaderCircular/LoaderCircular.props.story.tsx
+++ b/src/components/LoaderCircular/LoaderCircular.props.story.tsx
@@ -15,9 +15,9 @@ const LoaderCircular = styled(LC)`
   margin: 1rem;
 `;
 
-export function Size() {
+export function Size({ args }) {
   return (
-    <Layout.StoryVertical>
+    <Layout.StoryVertical {...args}>
       <LoaderCircular size="xs" />
       <LoaderCircular size="sm" />
       <LoaderCircular size="md" />
@@ -27,9 +27,10 @@ export function Size() {
   );
 }
 
-export function Format() {
+export function Format({ args }) {
   return (
     <Layout.StoryVertical
+      {...args}
       css={`
         color: ${red(500)};
       `}

--- a/src/components/Menu/Menu.examples.story.tsx
+++ b/src/components/Menu/Menu.examples.story.tsx
@@ -18,10 +18,10 @@ import {
 
 export default { title: 'components/Menu/examples', component: Menu };
 
-export function Simple() {
+export function Simple({ args }) {
   return (
     <Layout.StoryVertical>
-      <Menu style={{ padding: '1rem' }}>
+      <Menu style={{ padding: '1rem' }} {...args}>
         <Menu.Section title="Section 1">
           <Menu.Item active icon={<Home />}>
             <Header size="4">Can be any element</Header>
@@ -40,10 +40,10 @@ export function Simple() {
   );
 }
 
-export function Complex() {
+export function Complex({ args }) {
   return (
     <Layout.StoryVertical>
-      <Menu style={{ padding: '1rem' }}>
+      <Menu style={{ padding: '1rem' }} {...args}>
         <Menu.Section title="Section 1">
           <Menu.Item toggle>
             Item 1 S1

--- a/src/components/Menu/Menu.props.story.tsx
+++ b/src/components/Menu/Menu.props.story.tsx
@@ -7,10 +7,11 @@ import { Folder, Home, Grid, Gear } from '../../icons';
 
 export default { title: 'components/Menu/props', component: Menu };
 
-export function Format() {
+export function Format({ args }) {
   return (
     <Layout.StoryVertical>
       <Menu
+        {...args}
         format="basic"
         style={{ marginBottom: '1rem', padding: '1rem' }}
       >

--- a/src/components/Modal/Modal.examples.story.tsx
+++ b/src/components/Modal/Modal.examples.story.tsx
@@ -11,10 +11,11 @@ import { Paragraph, Header } from '../../typography';
 
 export default { title: 'components/Modal/examples' };
 
-export function ExternalState() {
+export function ExternalState({ args }) {
   return (
     <Layout.StoryVertical>
       <Modal
+        {...args}
         active={true}
         content={ModalContent}
         onOpen={() => console.log('open')}
@@ -24,7 +25,9 @@ export function ExternalState() {
   );
 }
 
-export const WithInputContent = () => <WithInputContentStory />;
+export const WithInputContent = ({ args }) => (
+  <WithInputContentStory />
+);
 function WithInputContentStory() {
   const [value, valueSet] = useState('');
 
@@ -37,6 +40,7 @@ function WithInputContentStory() {
   return (
     <Layout.StoryVertical>
       <Modal
+        {...args}
         content={
           <ModalStyled>
             <Modal.Header>Type something!</Modal.Header>
@@ -63,10 +67,7 @@ function WithInputContentStory() {
   );
 }
 
-export const ControlledWithDynamicContent = () => (
-  <ControlledWithDynamicContentStory />
-);
-function ControlledWithDynamicContentStory() {
+export function ControlledWithDynamicContent({ args }) {
   const [toggled, toggledSet] = useState(false);
   const [value, valueSet] = useState('');
   const [show, setShow] = useState(false);
@@ -127,6 +128,7 @@ function ControlledWithDynamicContentStory() {
   return (
     <Layout.StoryVertical>
       <Modal
+        {...args}
         active={show}
         content={toggled ? contentB : contentA}
         onOpen={() => console.log('open')}
@@ -172,7 +174,7 @@ const ModalContent = (
   </ModalStyled>
 );
 
-export const Custom = () => <CustomStory />;
+export const Custom = ({ args }) => <CustomStory />;
 function CustomStory() {
   const [active, activeSet] = useState(false);
 
@@ -182,6 +184,7 @@ function CustomStory() {
         Open Custom Modal
       </Button>
       <Modal
+        {...args}
         active={active}
         style={{ maxWidth: '35rem' }}
         content={

--- a/src/components/Modal/Modal.props.story.tsx
+++ b/src/components/Modal/Modal.props.story.tsx
@@ -9,20 +9,21 @@ import { Paragraph } from '../../typography';
 
 export default { title: 'components/Modal/props' };
 
-export function Feature() {
+export function Feature({ args }) {
   return (
     <Layout.StoryVertical>
-      <Modal content={FeatureModalContent} feature>
+      <Modal content={FeatureModalContent} feature {...args}>
         <Button>Open Feature Update Modal</Button>
       </Modal>
     </Layout.StoryVertical>
   );
 }
 
-export function Active() {
+export function Active({ args }) {
   return (
     <Layout.StoryVertical>
       <Modal
+        {...args}
         active={true}
         content={ModalContent}
         onOpen={() => console.log('open')}
@@ -32,10 +33,11 @@ export function Active() {
   );
 }
 
-export function Screen() {
+export function Screen({ args }) {
   return (
     <Layout.StoryVertical>
       <Modal
+        {...args}
         content={ModalContent}
         onOpen={() => console.log('open')}
         onClose={() => console.log('close')}
@@ -63,10 +65,10 @@ export function Screen() {
   );
 }
 
-export function Size() {
+export function Size({ args }) {
   return (
     <Layout.StoryVertical>
-      <Modal content={ModalContent} size="sm">
+      <Modal content={ModalContent} size="sm" {...args}>
         <Button>Open small modal</Button>
       </Modal>
       <Modal content={ModalContent} size="md">

--- a/src/components/Notice/Notice.examples.story.tsx
+++ b/src/components/Notice/Notice.examples.story.tsx
@@ -10,9 +10,9 @@ export default {
   title: 'components/Notice/examples',
 };
 
-export function Children() {
+export function Children({ args }) {
   return (
-    <Notice format="primary">
+    <Notice format="primary" {...args}>
       This Notice has <Link>multiple children</Link>{' '}
       <span>á mörgum tungumálum.</span>{' '}
       <Styled>This sentence has custom styles.</Styled>

--- a/src/components/Notice/Notice.props.story.tsx
+++ b/src/components/Notice/Notice.props.story.tsx
@@ -8,37 +8,37 @@ export default {
   title: 'components/Notice/props',
 };
 
-export function Primary() {
-  return <VariantStory format="primary" />;
+export function Primary({ args }) {
+  return <VariantStory format="primary" {...args} />;
 }
 
-export function PrimaryPill() {
+export function PrimaryPill({ args }) {
   return <VariantStory format="primary" pill />;
 }
 PrimaryPill.storyName = 'Primary (Pill)';
 
-export function Positive() {
-  return <VariantStory format="positive" />;
+export function Positive({ args }) {
+  return <VariantStory format="positive" {...args} />;
 }
 
-export function PositivePill() {
-  return <VariantStory format="positive" pill />;
+export function PositivePill({ args }) {
+  return <VariantStory format="positive" pill {...args} />;
 }
 PositivePill.storyName = 'Positive (Pill)';
 
-export function Negative() {
-  return <VariantStory format="negative" />;
+export function Negative({ args }) {
+  return <VariantStory format="negative" {...args} />;
 }
 
-export function NegativePill() {
-  return <VariantStory format="negative" pill />;
+export function NegativePill({ args }) {
+  return <VariantStory format="negative" pill {...args} />;
 }
 NegativePill.storyName = 'Negative (Pill)';
 
-function VariantStory({ format, pill = null }) {
+function VariantStory({ format, pill = null, ...args }) {
   return (
     <>
-      <Notice format={format} pill={pill}>
+      <Notice format={format} pill={pill} {...args}>
         Lorem ipsum dolor sit amet.
       </Notice>
 

--- a/src/components/Notification/Notification.examples.story.tsx
+++ b/src/components/Notification/Notification.examples.story.tsx
@@ -10,9 +10,10 @@ export default {
   component: Notification,
 };
 
-export function FancyContent() {
+export function FancyContent({ args }) {
   return (
     <Notification
+      {...args}
       automatic
       content={
         <>

--- a/src/components/Notification/Notification.props.story.tsx
+++ b/src/components/Notification/Notification.props.story.tsx
@@ -12,17 +12,18 @@ export default {
   },
 };
 
-export function Automatic() {
+export function Automatic({ args }) {
   return (
-    <Notification automatic content="Notification!">
+    <Notification automatic content="Notification!" {...args}>
       <Button>Show Notification</Button>
     </Notification>
   );
 }
 
-export function Action() {
+export function Action({ args }) {
   return (
     <Notification
+      {...args}
       actionLabel="Undo"
       content="Notification!"
       action={{
@@ -37,8 +38,7 @@ export function Action() {
   );
 }
 
-export const Controlled = () => <ControlledStory />;
-function ControlledStory() {
+export function Controlled({ args }) {
   const [showing, showingSet] = useState(false);
 
   function onComplete() {
@@ -49,6 +49,7 @@ function ControlledStory() {
   return (
     <>
       <Notification
+        {...args}
         content="Controlled Notification"
         duration={3000}
         onComplete={onComplete}

--- a/src/components/Pagination/Pagination.examples.story.tsx
+++ b/src/components/Pagination/Pagination.examples.story.tsx
@@ -22,8 +22,7 @@ function pageChange({ page, goto }) {
   };
 }
 
-export const GenericGrid = () => <GenericGridStory />;
-function GenericGridStory() {
+export function GenericGrid({ args }) {
   const ref = useRef(null);
 
   const { items, page, goto } = useFakeQuery({ total, pageSize });
@@ -47,6 +46,7 @@ function GenericGridStory() {
           Next
         </Next>
         <Pagination
+          {...args}
           active={page}
           total={total}
           pageSize={pageSize}
@@ -60,8 +60,7 @@ function GenericGridStory() {
   );
 }
 
-export const VideoGrid = () => <PaginationStory />;
-function PaginationStory() {
+export function VideoGrid({ args }) {
   const { items, page, goto } = useFakeVideos({ total, pageSize });
   const onChange = pageChange({ page, goto });
 
@@ -73,6 +72,7 @@ function PaginationStory() {
         ))}
       </Grid>
       <Pagination
+        {...args}
         active={page}
         total={total}
         pageSize={pageSize}

--- a/src/components/Path/Path.examples.story.tsx
+++ b/src/components/Path/Path.examples.story.tsx
@@ -12,13 +12,13 @@ const Path = styled(P)`
   margin: 0 0.5rem;
 `;
 
-export function CustomWidths() {
+export function CustomWidths({ args }) {
   const style = `padding: 0.5rem 1rem;`;
 
   return (
     <>
       <div css={style}>
-        <Path>
+        <Path {...args}>
           <Path.Link href="#" style={{ maxWidth: '5rem' }}>
             5rem max-width Path.Link
           </Path.Link>

--- a/src/components/Path/Path.story.tsx
+++ b/src/components/Path/Path.story.tsx
@@ -11,9 +11,9 @@ const Path = styled(P)`
   margin: 0 0.5rem;
 `;
 
-export function PathStory() {
+export function PathStory({ args }) {
   return (
-    <Path>
+    <Path {...args}>
       <Path.Link href="#">Home</Path.Link>
       <Path.Link href="#">Showcases</Path.Link>
       <Path.Current icon={<Globe />}>New Showcase</Path.Current>

--- a/src/components/PopOver/PopOver.examples.story.tsx
+++ b/src/components/PopOver/PopOver.examples.story.tsx
@@ -14,11 +14,12 @@ export default {
   title: 'components/PopOver/examples',
 };
 
-export function DynamicSize() {
+export function DynamicSize({ args }) {
   const [width, widthSet] = useState(240);
   return (
     <>
       <PopOver
+        {...args}
         active
         content={
           <div style={{ padding: '2rem', width }}>
@@ -43,10 +44,11 @@ export function DynamicSize() {
   );
 }
 
-export function Scrollable() {
+export function Scrollable({ args }) {
   return (
     <>
       <PopOver
+        {...args}
         content={PopScrollable}
         attach="bottom"
         style={{ width: '25rem' }}
@@ -57,11 +59,11 @@ export function Scrollable() {
   );
 }
 
-export function PopOverInsideLink() {
+export function PopOverInsideLink({ args }) {
   const [active, setActive] = useState(false);
 
   return (
-    <div style={{ display: 'flex' }}>
+    <div style={{ display: 'flex' }} {...args}>
       <Card
         href="#"
         key="1"

--- a/src/components/PopOver/PopOver.props.story.tsx
+++ b/src/components/PopOver/PopOver.props.story.tsx
@@ -10,10 +10,11 @@ import { blue } from '../../color';
 
 export default { title: 'components/PopOver/props' };
 
-export function Attach() {
+export function Attach({ args }) {
   return ANCHOR_POINTS.map((attach, i) => (
     <Fragment key={i}>
       <PopOver
+        {...args}
         content={PopList}
         attach={attach}
         style={{ zIndex: 5000 }}
@@ -25,7 +26,7 @@ export function Attach() {
   ));
 }
 
-export function Active() {
+export function Active({ args }) {
   const [active, setActive] = useState(false);
 
   return (
@@ -34,6 +35,7 @@ export function Active() {
         toggle
       </Button>
       <PopOver
+        {...args}
         content={
           <div>
             <Button

--- a/src/components/Progress/Progress.props.story.tsx
+++ b/src/components/Progress/Progress.props.story.tsx
@@ -18,10 +18,11 @@ const style = css`
   width: 50%;
 `;
 
-export function Size() {
+export function Size({ args }) {
   return (
     <>
       <Progress
+        {...args}
         animate={false}
         css={style}
         size="xs"
@@ -40,12 +41,17 @@ export function Size() {
 }
 Size.storyName = 'size';
 
-export function Variant() {
+export function Variant({ args }) {
   const [progress] = useSimulateProgress();
 
   return (
     <>
-      <Progress css={style} value={progress} variant="rainbow" />
+      <Progress
+        css={style}
+        value={progress}
+        variant="rainbow"
+        {...args}
+      />
       <Progress css={style} value={progress} variant="primary" />
       <Progress css={style} value={progress} variant="success" />
     </>

--- a/src/components/Ribbon/Ribbon.props.story.tsx
+++ b/src/components/Ribbon/Ribbon.props.story.tsx
@@ -13,29 +13,29 @@ const style = css`
   width: 50%;
 `;
 
-export function Variant() {
+export function Variant({ args }) {
   return (
     <>
-      <Ribbon css={style} variant="rainbow" />
+      <Ribbon css={style} variant="rainbow" {...args} />
       <Ribbon css={style} variant="mod" />
       <Ribbon css={style} variant="possessed" />
     </>
   );
 }
 
-export function Animate() {
+export function Animate({ args }) {
   return (
     <>
-      <Ribbon css={style} animate />
+      <Ribbon css={style} animate {...args} />
       <Ribbon css={style} animate={false} />
     </>
   );
 }
 
-export function Size() {
+export function Size({ args }) {
   return (
     <>
-      <Ribbon css={style} size="xs" />
+      <Ribbon css={style} size="xs" {...args} />
       <Ribbon css={style} size="sm" />
       <Ribbon css={style} size="md" />
       <Ribbon css={style} size="lg" />
@@ -44,10 +44,11 @@ export function Size() {
   );
 }
 
-export function Custom() {
+export function Custom({ args }) {
   return (
     <>
       <Ribbon
+        {...args}
         style={{
           background: 'linear-gradient(to right, red, yellow, red)',
           margin: '1rem 1rem',

--- a/src/components/Sidebar/examples/Live.story.tsx
+++ b/src/components/Sidebar/examples/Live.story.tsx
@@ -24,12 +24,12 @@ export default {
   component: Sidebar,
 };
 
-export function Live() {
+export function Live({ args }) {
   const state = useState('Sources');
 
   return (
     <Layout.FullBleed>
-      <Sidebar state={state}>
+      <Sidebar state={state} {...args}>
         <Sidebar.Item
           label="Sources"
           icon={<Camera />}

--- a/src/components/Sidebar/props/attach.tsx
+++ b/src/components/Sidebar/props/attach.tsx
@@ -7,10 +7,10 @@ import { Gear } from '../../../icons';
 import { Header as H } from '../../../typography';
 import { Layout } from '../../../storybook';
 
-export function Attach() {
+export function Attach({ args }) {
   return (
     <Layout.FullBleed>
-      <Sidebar attach="left">
+      <Sidebar attach="left" {...args}>
         <Sidebar.Item label="Item 1" icon={<Gear />}>
           <Header size="3" style={{ marginTop: 0 }}>
             Item 1

--- a/src/components/Sidebar/props/onOpen.tsx
+++ b/src/components/Sidebar/props/onOpen.tsx
@@ -7,9 +7,9 @@ import { Gear } from '../../../icons';
 import { Header as H } from '../../../typography';
 import { Layout } from '../../../storybook';
 
-export function onOpen() {
+export function onOpen({ args }) {
   return (
-    <Layout.FullBleed>
+    <Layout.FullBleed {...args}>
       <Sidebar
         attach="left"
         onOpen={(item) => console.log('Open ' + item)}

--- a/src/components/Sidebar/props/state.tsx
+++ b/src/components/Sidebar/props/state.tsx
@@ -7,12 +7,12 @@ import { Gear } from '../../../icons';
 import { Header as H } from '../../../typography';
 import { Layout } from '../../../storybook';
 
-export function State() {
+export function State({ args }) {
   const state = useState('Item 2');
 
   return (
     <Layout.FullBleed>
-      <Sidebar attach="left" state={state}>
+      <Sidebar attach="left" state={state} {...args}>
         <Sidebar.Item label="Item 1" icon={<Gear />}>
           <Header size="3">Item 1</Header>
         </Sidebar.Item>

--- a/src/components/Tabs/Tabs.props.story.tsx
+++ b/src/components/Tabs/Tabs.props.story.tsx
@@ -13,11 +13,11 @@ const Tabs = styled(T)`
   margin-bottom: 2rem;
 `;
 
-export function Format() {
+export function Format({ args }) {
   return (
     ['basic', 'soft', 'alternative', 'secondary', 'primary'] as const
   ).map((format, key) => (
-    <Tabs format={format} key={key}>
+    <Tabs format={format} key={key} {...args}>
       <Tabs.Panel
         label="Tab 0"
         onActivate={() => console.log('Clicked Tab 0')}
@@ -45,9 +45,9 @@ export function Format() {
 }
 Format.storyName = 'format';
 
-export function Variant() {
+export function Variant({ args }) {
   return (
-    <Tabs variant="inlay">
+    <Tabs variant="inlay" {...args}>
       <Tabs.Panel
         label="Tab 0"
         onActivate={() => console.log('Clicked Tab 0')}
@@ -75,9 +75,9 @@ export function Variant() {
 }
 Variant.storyName = 'variant';
 
-export function Pill() {
+export function Pill({ args }) {
   return (
-    <Tabs pill variant="inlay">
+    <Tabs pill variant="inlay" {...args}>
       <Tabs.Panel
         label="Tab 0"
         onActivate={() => console.log('Clicked Tab 0')}

--- a/src/components/Tag/Tag.story.tsx
+++ b/src/components/Tag/Tag.story.tsx
@@ -35,9 +35,9 @@ const Template: Story<Props> = (args) => {
 export const Controls = Template.bind({});
 Controls.storyName = 'Tag';
 
-export function Size() {
+export function Size({ args }) {
   return (
-    <Layout.StoryVertical defaultWidth>
+    <Layout.StoryVertical defaultWidth {...args}>
       <Tag size="xs">Documentary</Tag>
       <Tag size="sm">Animation</Tag>
       <Tag size="md">Narrative</Tag>
@@ -46,9 +46,10 @@ export function Size() {
   );
 }
 
-export function Src() {
+export function Src({ args }) {
   return (
     <Tag
+      {...args}
       size="lg"
       src="https://i.vimeocdn.com/video/562859486_270x270.jpg"
     >
@@ -57,9 +58,10 @@ export function Src() {
   );
 }
 
-export function onClose() {
+export function onClose({ args }) {
   return (
     <Tag
+      {...args}
       size="lg"
       onClose={{ reject: () => alert('deleted this tag') }}
     >

--- a/src/components/Tip/Tip.examples.story.tsx
+++ b/src/components/Tip/Tip.examples.story.tsx
@@ -14,13 +14,13 @@ export default {
   component: Tip,
 };
 
-export function TipPopOverCombo() {
+export function TipPopOverCombo({ args }) {
   const [active, activeSet] = useState(false);
 
   return (
     <Layout.StoryVertical center>
       <div style={{ textAlign: 'center' }}>
-        <Tip content="I am Tip" attach="top">
+        <Tip content="I am Tip" attach="top" {...args}>
           <span style={{ display: 'inline-block' }}>
             <PopOver content={PopList} active={active}>
               <Button
@@ -55,7 +55,7 @@ const PopList = (
   </>
 );
 
-export function Fancy() {
+export function Fancy({ args }) {
   preload('http://placekitten.com/320/120');
 
   const content = (
@@ -74,6 +74,7 @@ export function Fancy() {
   return (
     <Layout.StoryVertical center style={{ paddingTop: '6rem' }}>
       <Tip
+        {...args}
         content={content}
         attach="bottom"
         trigger="click"
@@ -90,10 +91,11 @@ function preload(src) {
   image.src = src;
 }
 
-export function TextWrapping() {
+export function TextWrapping({ args }) {
   return (
     <Layout.StoryVertical center>
       <Tip
+        {...args}
         content="Tips with long strings passed to the `content` prop will automatically wrap."
         attach="top"
       >

--- a/src/components/Tip/Tip.props.story.tsx
+++ b/src/components/Tip/Tip.props.story.tsx
@@ -9,13 +9,18 @@ import { ANCHOR_POINTS } from '../../utils';
 
 export default { title: 'components/Tip/props', component: Tip };
 
-export function Active() {
+export function Active({ args }) {
   const [active, activeSet] = useState(false);
 
   return (
     <Layout.StoryVertical center>
       <div style={{ textAlign: 'center' }}>
-        <Tip content="I am Tip" attach="top" active={active}>
+        <Tip
+          content="I am Tip"
+          attach="top"
+          active={active}
+          {...args}
+        >
           <Button
             onClick={() => activeSet((active) => !active)}
             fluid
@@ -29,12 +34,12 @@ export function Active() {
 }
 Active.storyName = 'active';
 
-export function Attach() {
+export function Attach({ args }) {
   return (
     <Layout.StoryVertical center>
       {ANCHOR_POINTS.map((attach, i) => (
         <Fragment key={i}>
-          <Tip content="I am Tip" attach={attach}>
+          <Tip content="I am Tip" attach={attach} {...args}>
             <Button>Tip {attach}</Button>
           </Tip>
           <br />
@@ -45,11 +50,16 @@ export function Attach() {
 }
 Attach.storyName = 'attach';
 
-export function Trigger() {
+export function Trigger({ args }) {
   return (
     <Layout.StoryVertical center>
       <div>
-        <Tip content="I am Tip" attach="top" trigger="hover">
+        <Tip
+          content="I am Tip"
+          attach="top"
+          trigger="hover"
+          {...args}
+        >
           <Button fluid style={{ marginBottom: '2rem' }}>
             Hover Tip
           </Button>
@@ -63,13 +73,14 @@ export function Trigger() {
 }
 Trigger.storyName = 'trigger';
 
-export function Variant() {
+export function Variant({ args }) {
   const text =
     'Embed your videos anywhere on the web. You can also embed GIFs of your videos in your emails to increase engagement.';
 
   return (
     <Layout.StoryVertical center>
       <Tip
+        {...args}
         attach="top"
         variant="simple"
         trigger="click"
@@ -106,12 +117,12 @@ export function Variant() {
 }
 Variant.storyName = 'variant';
 
-export function Pill() {
+export function Pill({ args }) {
   return (
     <Layout.StoryVertical center>
       {ANCHOR_POINTS.map((attach, i) => (
         <Fragment key={i}>
-          <Tip content="I am Tip" attach={attach} pill>
+          <Tip content="I am Tip" attach={attach} pill {...args}>
             <Button>Tip {attach}</Button>
           </Tip>
           <br />

--- a/src/components/inputs/Checkbox/Checkbox.props.story.tsx
+++ b/src/components/inputs/Checkbox/Checkbox.props.story.tsx
@@ -10,10 +10,11 @@ export default {
   title: 'components/Checkbox/props',
 };
 
-export function Disabled() {
+export function Disabled({ args }) {
   return (
     <Layout.StoryVertical>
       <Checkbox
+        {...args}
         label="Disabled unchecked Checkbox"
         name="demoCheckboxDisabled"
         id="CheckboxDisabled"
@@ -32,10 +33,11 @@ export function Disabled() {
   );
 }
 
-export function Status() {
+export function Status({ args }) {
   return (
     <Layout.StoryVertical>
       <Checkbox
+        {...args}
         label="Checkbox with status set to negative"
         name="demoCheckbox1"
         status="negative"
@@ -55,7 +57,7 @@ export function Status() {
   );
 }
 
-export function Checked() {
+export function Checked({ args }) {
   const [checked, setChecked] = useState(true);
 
   return (
@@ -65,6 +67,7 @@ export function Checked() {
         Checkbox is {checked.toString()}
       </Button>
       <Checkbox
+        {...args}
         label="Checkbox 1 (Medium)"
         name="demoCheckbox1"
         id="Checkbox1"

--- a/src/components/inputs/Checkbox/CheckboxSet.props.story.tsx
+++ b/src/components/inputs/Checkbox/CheckboxSet.props.story.tsx
@@ -10,14 +10,14 @@ export default {
   title: 'components/CheckboxSet/props',
 };
 
-export function Coupled() {
+export function Coupled({ args }) {
   return (
     <Layout.StoryVertical>
       <Header size="5">
         The `coupled` prop will override the children when the parent
         value changes.
       </Header>
-      <CheckboxSet label="coupled" coupled>
+      <CheckboxSet label="coupled" coupled {...args}>
         <Checkbox label="coupled" />
         <Checkbox label="coupled" />
       </CheckboxSet>
@@ -26,7 +26,7 @@ export function Coupled() {
 }
 Coupled.storyName = 'coupled';
 
-export function Toggled() {
+export function Toggled({ args }) {
   const checkboxRef = useRef(null);
 
   return (
@@ -36,6 +36,7 @@ export function Toggled() {
         selected.
       </Header>
       <CheckboxSet
+        {...args}
         ref={checkboxRef}
         label="toggled"
         toggled
@@ -65,7 +66,7 @@ export function Toggled() {
 }
 Toggled.storyName = 'toggled';
 
-export function DefaultChecked() {
+export function DefaultChecked({ args }) {
   return (
     <Layout.StoryVertical>
       <Header size="3">Toggled</Header>
@@ -89,7 +90,12 @@ export function DefaultChecked() {
         `indeterminate`.
       </Header>
 
-      <CheckboxSet label="defaultChecked" toggled defaultChecked>
+      <CheckboxSet
+        label="defaultChecked"
+        toggled
+        defaultChecked
+        {...args}
+      >
         <Checkbox label="." />
         <Checkbox label="." />
         <Checkbox
@@ -178,9 +184,9 @@ export function DefaultChecked() {
 }
 DefaultChecked.storyName = 'defaultChecked';
 
-export function Disabled() {
+export function Disabled({ args }) {
   return (
-    <CheckboxSet label="disabled" disabled>
+    <CheckboxSet label="disabled" disabled {...args}>
       <Checkbox label="disabled" />
       <Checkbox label="disabled" />
     </CheckboxSet>

--- a/src/components/inputs/ColorSelect/ColorSelect.props.story.tsx
+++ b/src/components/inputs/ColorSelect/ColorSelect.props.story.tsx
@@ -11,10 +11,11 @@ export default {
   title: 'components/ColorSelect/props',
 };
 
-export function Children() {
+export function Children({ args }) {
   return (
     <Layout.StoryVertical defaultWidth>
       <ColorSelect
+        {...args}
         onChange={(HEX) =>
           console.log(
             `onChange: %c ${HEX}`,
@@ -29,13 +30,14 @@ export function Children() {
 }
 Children.storyName = 'children';
 
-export function Attach() {
+export function Attach({ args }) {
   return (
     <Layout.StoryVertical
       center
       style={{ minHeight: '75vh', justifyContent: 'center' }}
     >
       <ColorSelect
+        {...args}
         width={320}
         height={200}
         attach="top"

--- a/src/components/inputs/CopyField/CopyField.props.story.tsx
+++ b/src/components/inputs/CopyField/CopyField.props.story.tsx
@@ -9,10 +9,11 @@ export default {
   title: 'components/CopyField/props',
 };
 
-export function Format() {
+export function Format({ args }) {
   return (
     <Layout.StoryVertical>
       <CopyField
+        {...args}
         format="primary"
         value="http://www.vimeo.com"
         messages={{ success: 'Copied!' }}
@@ -26,11 +27,12 @@ export function Format() {
   );
 }
 
-export function Size() {
+export function Size({ args }) {
   return (
     <Layout.StoryVertical>
       {(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size, i) => (
         <CopyField
+          {...args}
           key={i}
           size={size}
           value="http://www.vimeo.com"
@@ -41,10 +43,11 @@ export function Size() {
   );
 }
 
-export function Variant() {
+export function Variant({ args }) {
   return (
     <Layout.StoryVertical>
       <CopyField
+        {...args}
         variant="basic"
         value="http://www.vimeo.com"
         messages={{ success: 'Copied!' }}
@@ -58,10 +61,11 @@ export function Variant() {
   );
 }
 
-export function Status() {
+export function Status({ args }) {
   return (
     <Layout.StoryVertical>
       <CopyField
+        {...args}
         status="negative"
         value="http://www.vimeo.com"
         messages={{ success: 'Copied!' }}
@@ -75,10 +79,11 @@ export function Status() {
   );
 }
 
-export function Children() {
+export function Children({ args }) {
   return (
     <Layout.StoryVertical>
       <CopyField
+        {...args}
         value="http://www.vimeo.com"
         messages={{ success: 'Copied!' }}
       >

--- a/src/components/inputs/Dates/Calendar/Calendar.story.tsx
+++ b/src/components/inputs/Dates/Calendar/Calendar.story.tsx
@@ -10,7 +10,7 @@ export default {
   title: 'components/Dates/Calendar',
 };
 
-export function CalendarStory() {
+export function CalendarStory({ args }) {
   const [date, setDate] = useState(new Date());
 
   return (
@@ -20,6 +20,7 @@ export function CalendarStory() {
         is not exported by itself.
       </Header>
       <Calendar
+        {...args}
         selected={date}
         onClick={(date) => setDate(date)}
         css={`

--- a/src/components/inputs/Dates/DateRange/DateRange.props.story.tsx
+++ b/src/components/inputs/Dates/DateRange/DateRange.props.story.tsx
@@ -13,10 +13,11 @@ export default {
   title: 'components/Dates/DateRange/props',
 };
 
-export function Presets() {
+export function Presets({ args }) {
   return (
     <Layout.StoryVertical center>
       <DateRangeButton
+        {...args}
         presets={presets}
         onPresetClick={(presetValue: PresetValue) => {
           console.log('Preset Value Selected - ', presetValue);
@@ -26,10 +27,11 @@ export function Presets() {
   );
 }
 
-export function InputLabel() {
+export function InputLabel({ args }) {
   return (
     <Layout.StoryVertical center>
       <DateRangeButton
+        {...args}
         startInputLabel="Fecha de inicio"
         endInputLabel="Fecha final"
       />
@@ -37,34 +39,40 @@ export function InputLabel() {
   );
 }
 
-export function MinDate() {
+export function MinDate({ args }) {
   return (
     <Layout.StoryVertical center>
-      <DateRangeButton minDate={new Date()} />
+      <DateRangeButton minDate={new Date()} {...args} />
     </Layout.StoryVertical>
   );
 }
 
-export function MaxDate() {
+export function MaxDate({ args }) {
   return (
     <Layout.StoryVertical center>
-      <DateRangeButton maxDate={new Date()} />
+      <DateRangeButton maxDate={new Date()} {...args} />
     </Layout.StoryVertical>
   );
 }
 
-export function Translation() {
+export function Translation({ args }) {
   return (
     <Layout.StoryVertical center>
-      <DateRangeButton translation={translations['ko-KR']} />
+      <DateRangeButton
+        translation={translations['ko-KR']}
+        {...args}
+      />
     </Layout.StoryVertical>
   );
 }
 
-export function CustomTranslation() {
+export function CustomTranslation({ args }) {
   return (
     <Layout.StoryVertical center>
-      <DateRangeButton translation={backWardsTranslations} />
+      <DateRangeButton
+        translation={backWardsTranslations}
+        {...args}
+      />
     </Layout.StoryVertical>
   );
 }

--- a/src/components/inputs/Dates/DateSelect/DateSelect.props.story.tsx
+++ b/src/components/inputs/Dates/DateSelect/DateSelect.props.story.tsx
@@ -11,14 +11,14 @@ export default {
   title: 'components/Dates/DateSelect/props',
 };
 
-export const InitialMonth = () => <InitialMonthStory />;
-function InitialMonthStory() {
+export function InitialMonth({ args }) {
   const initialMonth = new Date('01/01/2032');
   const [date, dateSet] = useState(initialMonth);
 
   return (
     <Layout.StoryVertical>
       <DateSelect
+        {...args}
         active
         onSelect={(date) => dateSet(date)}
         initialMonth={initialMonth}
@@ -29,8 +29,7 @@ function InitialMonthStory() {
   );
 }
 
-export const MinMaxDate = () => <MinMaxDateStory />;
-function MinMaxDateStory() {
+export function MinMaxDate({ args }) {
   const today = new Date();
   const day = 86400000;
   const selected = new Date(today.getTime() + day * 2);
@@ -41,6 +40,7 @@ function MinMaxDateStory() {
   return (
     <Layout.StoryVertical>
       <DateSelect
+        {...args}
         active
         onSelect={(date) => dateSet(date)}
         min={minDate}
@@ -53,7 +53,7 @@ function MinMaxDateStory() {
   );
 }
 
-export function Active() {
+export function Active({ args }) {
   const ref = useRef(null);
   const [active, setActive] = useState(false);
 
@@ -64,6 +64,7 @@ export function Active() {
   return (
     <Layout.StoryVertical>
       <DateSelect
+        {...args}
         active={active}
         ref={ref}
         onSelect={() => {
@@ -78,13 +79,14 @@ export function Active() {
   );
 }
 
-export function Value() {
+export function Value({ args }) {
   const selected = new Date();
   const [date, dateSet] = useState(selected);
 
   return (
     <Layout.StoryVertical>
       <DateSelect
+        {...args}
         active
         value={date}
         onSelect={(date) => {
@@ -97,13 +99,14 @@ export function Value() {
   );
 }
 
-export function DefaultValue() {
+export function DefaultValue({ args }) {
   const selected = new Date();
   const [date, dateSet] = useState(null);
 
   return (
     <Layout.StoryVertical>
       <DateSelect
+        {...args}
         active
         defaultValue={selected}
         value={date}

--- a/src/components/inputs/Dropzone/Dropzone.props.story.tsx
+++ b/src/components/inputs/Dropzone/Dropzone.props.story.tsx
@@ -38,7 +38,7 @@ const onChange = (event: DropChangeEvent) => {
 
 const formats = ['primary', 'secondary'] as const;
 
-export function Formats() {
+export function Formats({ args }) {
   const style = {
     maxWidth: '40rem',
     height: '5rem',
@@ -46,7 +46,7 @@ export function Formats() {
   };
 
   return formats.map((format) => (
-    <div key={format} style={{ marginBottom: '4rem' }}>
+    <div key={format} style={{ marginBottom: '4rem' }} {...args}>
       <Header size="5">{format}</Header>
       <Dropzone format={format} style={style}>
         <Header size="3">Drag files here</Header>
@@ -65,8 +65,7 @@ export function Formats() {
   ));
 }
 
-export const Custom = () => <CustomStory />;
-function CustomStory() {
+export function Custom({ args }) {
   // change primary from blue to amethyst.
   const theme = useLocalTheme({
     formats: { primary: amethyst(500) },
@@ -76,6 +75,7 @@ function CustomStory() {
     <>
       <Header size="5">custom</Header>
       <Dropzone
+        {...args}
         onChange={onChange}
         theme={theme}
         style={{ maxWidth: '40rem', marginBottom: '1rem' }}

--- a/src/components/inputs/Password/Password.props.story.tsx
+++ b/src/components/inputs/Password/Password.props.story.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'components/Password/props',
 };
 
-export function Label() {
+export function Label({ args }) {
   return (
     <div
       css={`
@@ -14,12 +14,12 @@ export function Label() {
         max-width: 30rem;
       `}
     >
-      <Password label="Input (Password)" />
+      <Password label="Input (Password)" {...args} />
     </div>
   );
 }
 
-export function Floating() {
+export function Floating({ args }) {
   return (
     <div
       css={`
@@ -27,7 +27,7 @@ export function Floating() {
         max-width: 30rem;
       `}
     >
-      <Password label="Input (Password)" floating />
+      <Password label="Input (Password)" floating {...args} />
     </div>
   );
 }

--- a/src/components/inputs/Radio/Radio.examples.story.tsx
+++ b/src/components/inputs/Radio/Radio.examples.story.tsx
@@ -13,7 +13,7 @@ const Radio = styled(R)`
   margin: 1rem;
 `;
 
-export function Controlled() {
+export function Controlled({ args }) {
   const [checked, setChecked] = useState('2');
 
   return (
@@ -22,6 +22,7 @@ export function Controlled() {
         Radio is {checked}
       </Button>
       <RadioSet
+        {...args}
         defaultValue={checked}
         onChange={(e) => setChecked(e.currentTarget.value)}
       >
@@ -32,12 +33,12 @@ export function Controlled() {
   );
 }
 
-export function Horizontal() {
+export function Horizontal({ args }) {
   const style = { display: 'inline-flex' };
 
   return (
     <>
-      <RadioSet>
+      <RadioSet {...args}>
         <Radio style={style} />
         <Radio style={style} />
         <Radio style={style} />
@@ -46,10 +47,10 @@ export function Horizontal() {
   );
 }
 
-export function CustomElement() {
+export function CustomElement({ args }) {
   return (
     <>
-      <RadioSet>
+      <RadioSet {...args}>
         <Radio checked>
           <Custom />
         </Radio>

--- a/src/components/inputs/Radio/Radio.story.tsx
+++ b/src/components/inputs/Radio/Radio.story.tsx
@@ -28,9 +28,10 @@ Controls.args = {
   label: 'Sample Radio',
 };
 
-export function RadioSetStory() {
+export function RadioSetStory({ args }) {
   return (
     <RadioSet
+      {...args}
       defaultValue="2"
       onChange={(e) => console.log(e.currentTarget)}
     >

--- a/src/components/inputs/Search/Search.props.story.tsx
+++ b/src/components/inputs/Search/Search.props.story.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'components/Search/props',
 };
 
-export function Size() {
+export function Size({ args }) {
   return sizes.map((size, key) => (
     <div
       key={key}
@@ -16,6 +16,7 @@ export function Size() {
       `}
     >
       <Search
+        {...args}
         label={'search size ' + size}
         placeholder="Search our videos"
         size={size}
@@ -24,7 +25,7 @@ export function Size() {
   ));
 }
 
-export function Format() {
+export function Format({ args }) {
   return formats.map((format, key) => (
     <div
       key={key}
@@ -34,6 +35,7 @@ export function Format() {
       `}
     >
       <Search
+        {...args}
         label={'search format ' + format}
         placeholder="Search our videos"
         format={format}
@@ -42,7 +44,7 @@ export function Format() {
   ));
 }
 
-export function Variant() {
+export function Variant({ args }) {
   return variants.map((variant, key) => (
     <div
       key={key}
@@ -52,6 +54,7 @@ export function Variant() {
       `}
     >
       <Search
+        {...args}
         label={'search variant ' + variant}
         placeholder="Search our videos"
         variant={variant}

--- a/src/components/inputs/Select/Select.props.story.tsx
+++ b/src/components/inputs/Select/Select.props.story.tsx
@@ -13,10 +13,10 @@ export default {
   title: 'components/Select/props',
 };
 
-export function Disabled() {
+export function Disabled({ args }) {
   return (
     <Layout.StoryVertical>
-      <Select label="Select disabled" disabled>
+      <Select label="Select disabled" disabled {...args}>
         <Select.Option value="1">Value 1</Select.Option>
         <Select.Option value="2">
           Value 2 has a long label
@@ -27,10 +27,11 @@ export function Disabled() {
 }
 Disabled.storyName = 'disabled';
 
-export function Messages() {
+export function Messages({ args }) {
   return (
     <Layout.StoryVertical>
       <Select
+        {...args}
         label="Select with pre message"
         messages={{ pre: 'This is a pre message' }}
       >
@@ -73,10 +74,11 @@ export function Messages() {
 }
 Messages.storyName = 'messages';
 
-export function Status() {
+export function Status({ args }) {
   return (
     <Layout.StoryVertical>
       <Select
+        {...args}
         label="I feel validated!"
         status="positive"
         messages={{ help: 'Great!' }}
@@ -100,10 +102,11 @@ export function Status() {
   );
 }
 Status.storyName = 'status';
-export function DefaultValue() {
+export function DefaultValue({ args }) {
   return (
     <Layout.StoryVertical>
       <Select
+        {...args}
         label="Select with defaultValue of 2"
         defaultValue="2"
         onChange={(e) =>
@@ -120,12 +123,13 @@ export function DefaultValue() {
 }
 DefaultValue.storyName = 'defaultValue';
 
-export function Value() {
+export function Value({ args }) {
   const [value, valueSet] = useState('1');
 
   return (
     <Layout.StoryVertical>
       <Select
+        {...args}
         label="'value' state is controlled externally"
         value={value}
         onChange={(e) => {
@@ -143,12 +147,17 @@ export function Value() {
 }
 Value.storyName = 'value';
 
-export function Size() {
+export function Size({ args }) {
   return (
     <Layout.StoryVertical>
       {(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size, i) => {
         return (
-          <Select key={i} label={`${size} Select`} size={size}>
+          <Select
+            {...args}
+            key={i}
+            label={`${size} Select`}
+            size={size}
+          >
             <Select.Option value="1">Value 1</Select.Option>
             <Select.Option value="2">
               Value 2 has a long label
@@ -161,10 +170,11 @@ export function Size() {
 }
 Size.storyName = 'size';
 
-export function Faux() {
+export function Faux({ args }) {
   return (
     <Layout.StoryVertical>
       <Select
+        {...args}
         label="Faux select"
         onChange={(e) => {
           console.log('Selected Option', e.target.value, e);
@@ -191,7 +201,7 @@ export function Faux() {
 }
 Faux.storyName = 'faux';
 
-export function FauxExternalState() {
+export function FauxExternalState({ args }) {
   const [value, valueSet] = useState(null);
 
   function onChange(event) {
@@ -202,6 +212,7 @@ export function FauxExternalState() {
   return (
     <Layout.StoryVertical>
       <Select
+        {...args}
         label="Faux select"
         onChange={onChange}
         placeholder="Please select an option."
@@ -249,10 +260,10 @@ const Notice = styled.div`
   }
 `;
 
-export function Pill() {
+export function Pill({ args }) {
   return (
     <Layout.StoryVertical>
-      <Select label="Select disabled" pill>
+      <Select label="Select disabled" pill {...args}>
         <Select.Option value="1">Value 1</Select.Option>
         <Select.Option value="2">
           Value 2 has a long label

--- a/src/components/inputs/Slider/Slider.props.story.tsx
+++ b/src/components/inputs/Slider/Slider.props.story.tsx
@@ -9,10 +9,11 @@ export default {
   component: Slider,
 };
 
-export function Range() {
+export function Range({ args }) {
   return (
     <Layout.StoryPadded>
       <Slider
+        {...args}
         range
         initialValues={[20, 50]}
         formatter={(value) => value + 'm'}
@@ -25,10 +26,11 @@ export function Range() {
   );
 }
 
-export function MinMax() {
+export function MinMax({ args }) {
   return (
     <Layout.StoryPadded>
       <Slider
+        {...args}
         range
         min={10}
         max={90}
@@ -42,10 +44,11 @@ export function MinMax() {
   );
 }
 
-export function EditableLabel() {
+export function EditableLabel({ args }) {
   return (
     <Layout.StoryPadded>
       <Slider
+        {...args}
         editableLabel
         range
         onChange={(n) => console.log(n?.target?.value)}

--- a/src/components/inputs/TextArea/TextArea.props.story.tsx
+++ b/src/components/inputs/TextArea/TextArea.props.story.tsx
@@ -18,10 +18,11 @@ const TextArea = styled(TA)`
 
 const TextAreaWCC = withCharacterCount(TextArea);
 
-export function Format() {
+export function Format({ args }) {
   return (
     <Layout.StoryVertical>
       <TextArea
+        {...args}
         label="Text area"
         format="negative"
         messages={{ error: 'This is an error.' }}
@@ -35,10 +36,11 @@ export function Format() {
   );
 }
 
-export function withCharacterCountStory() {
+export function withCharacterCountStory({ args }) {
   return (
     <Layout.StoryVertical>
       <TextAreaWCC
+        {...args}
         label="Text area with character count"
         defaultValue="lorem ipsum dolor"
       />
@@ -53,7 +55,7 @@ export function withCharacterCountStory() {
 }
 withCharacterCountStory.storyName = 'withCharacterCount';
 
-export function DefaultValue() {
+export function DefaultValue({ args }) {
   const ref = useRef(null);
   const resetText = 'The default text.';
   const reset = () => (ref.current.value = resetText);
@@ -62,6 +64,7 @@ export function DefaultValue() {
     <Layout.StoryVertical>
       <Button onClick={reset}>Reset</Button>
       <TextArea
+        {...args}
         label="Click the button to reset to defaultValue"
         defaultValue={resetText}
         ref={ref}

--- a/src/components/inputs/Toggle/Toggle.props.story.tsx
+++ b/src/components/inputs/Toggle/Toggle.props.story.tsx
@@ -11,11 +11,12 @@ export default {
   title: 'components/Toggle/props',
 };
 
-export function Size() {
+export function Size({ args }) {
   return (
     <Layout.StoryVertical>
       {(['sm', 'md', 'lg', 'xl'] as const).map((size, i) => (
         <Toggle
+          {...args}
           key={i}
           size={size}
           label="Toggle"
@@ -28,10 +29,11 @@ export function Size() {
   );
 }
 
-export function Label() {
+export function Label({ args }) {
   return (
     <Layout.StoryVertical>
       <Toggle
+        {...args}
         label="Toggle 1"
         name="demoToggle1"
         id="Toggle1"
@@ -53,10 +55,11 @@ export function Label() {
   );
 }
 
-export function Error() {
+export function Error({ args }) {
   return (
     <Layout.StoryVertical>
       <Toggle
+        {...args}
         label="Errored Field"
         name="errorToggle"
         status="negative"
@@ -68,10 +71,11 @@ export function Error() {
   );
 }
 
-export function Disabled() {
+export function Disabled({ args }) {
   return (
     <Layout.StoryVertical>
       <Toggle
+        {...args}
         label="DisabledField"
         name="demoToggleDisabled"
         id="ToggleDisabled"
@@ -82,7 +86,7 @@ export function Disabled() {
   );
 }
 
-export function Checked() {
+export function Checked({ args }) {
   const [checked, setChecked] = useState(true);
   return (
     <Layout.StoryVertical>
@@ -91,6 +95,7 @@ export function Checked() {
         Toggle is {checked.toString()}
       </Button>
       <Toggle
+        {...args}
         label="Toggle"
         name="demoToggle1"
         id="Toggle1"
@@ -101,11 +106,12 @@ export function Checked() {
   );
 }
 
-export function Icon() {
+export function Icon({ args }) {
   const [checked, setChecked] = useState(true);
   return (
     <Layout.StoryVertical>
       <Toggle
+        {...args}
         onChange={() => setChecked((checked) => !checked)}
         label="Toggle with Icon"
         name="demoToggle1"

--- a/src/components/inputs/withCharacterCount/withCharacterCount.story.tsx
+++ b/src/components/inputs/withCharacterCount/withCharacterCount.story.tsx
@@ -9,10 +9,11 @@ import { Input } from '../../index';
 
 export default { title: 'Utilties/Character Count' };
 
-export function Common() {
+export function Common({ args }) {
   return (
     <Story title="Character Count">
       <InputWithCharacterCount
+        {...args}
         id="someId1"
         label="Input (text) with character count"
       />

--- a/src/typography/BigStat/BigStat.props.story.tsx
+++ b/src/typography/BigStat/BigStat.props.story.tsx
@@ -9,10 +9,12 @@ export default {
   component: BigStat,
 };
 
-export function ContentEditable() {
+export function ContentEditable({ args }) {
   return (
     <Layout.StoryVertical>
-      <BigStat contentEditable>12.2k</BigStat>
+      <BigStat contentEditable {...args}>
+        12.2k
+      </BigStat>
     </Layout.StoryVertical>
   );
 }

--- a/src/typography/BigStat/BigStat.story.tsx
+++ b/src/typography/BigStat/BigStat.story.tsx
@@ -6,10 +6,10 @@ import { Layout } from '../../storybook';
 
 export default { title: 'typography/BigStat', component: BigStat };
 
-export function Common() {
+export function Common({ args }) {
   return (
     <Layout.StoryVertical>
-      <BigStat>12.2k</BigStat>
+      <BigStat {...args}>12.2k</BigStat>
     </Layout.StoryVertical>
   );
 }

--- a/src/typography/Header/Header.props.story.tsx
+++ b/src/typography/Header/Header.props.story.tsx
@@ -10,10 +10,12 @@ export default {
   component: Header,
 };
 
-export function Size() {
+export function Size({ args }) {
   return (
     <div>
-      <Header size="plusUltra">Header Plus Ultra</Header>
+      <Header size="plusUltra" {...args}>
+        Header Plus Ultra
+      </Header>
       <Header size="1">Header 1</Header>
       <Header size="2">Header 2</Header>
       <Header size="3">Header 3</Header>
@@ -26,10 +28,10 @@ export function Size() {
 }
 Size.storyName = 'size';
 
-export function Variant() {
+export function Variant({ args }) {
   return (
     <Layout.StoryVertical>
-      <Header size="1" variant="thin">
+      <Header size="1" variant="thin" {...args}>
         Header 1
       </Header>
       <Header size="2" variant="thin">
@@ -55,11 +57,12 @@ export function Variant() {
 }
 Variant.storyName = 'variant';
 
-export function Editable() {
+export function Editable({ args }) {
   return (
     <Layout.StoryVertical>
       <Row>
         <Header
+          {...args}
           size="plusUltra"
           placeholder="Edit me!"
           contentEditable

--- a/src/typography/Link/Link.props.story.tsx
+++ b/src/typography/Link/Link.props.story.tsx
@@ -6,10 +6,12 @@ import { Layout } from '../../storybook';
 
 export default { title: 'typography/Link/props', component: Link };
 
-export function Format() {
+export function Format({ args }) {
   return (
     <Layout.StoryVertical defaultWidth>
-      <Link format="basic">Click me!</Link>
+      <Link format="basic" {...args}>
+        Click me!
+      </Link>
       <Link format="soft">Click me!</Link>
       <Link format="primary">Click me!</Link>
       <Link format="positive">Click me!</Link>
@@ -19,10 +21,10 @@ export function Format() {
 }
 Format.storyName = 'format';
 
-export function Variant() {
+export function Variant({ args }) {
   return (
     <Layout.StoryVertical defaultWidth>
-      <Link>Click me!</Link>
+      <Link {...args}>Click me!</Link>
       <Link variant="minimal">Click me!</Link>
     </Layout.StoryVertical>
   );

--- a/src/typography/Link/examples/Custom.story.tsx
+++ b/src/typography/Link/examples/Custom.story.tsx
@@ -6,10 +6,11 @@ import { Layout } from '../../../storybook';
 
 export default { title: 'typography/Link/examples', component: Link };
 
-export function Custom() {
+export function Custom({ args }) {
   return (
     <Layout.StoryVertical defaultWidth>
       <Link
+        {...args}
         css={`
           font-weight: 800;
         `}

--- a/src/typography/Paragraph/Paragraph.props.story.tsx
+++ b/src/typography/Paragraph/Paragraph.props.story.tsx
@@ -9,10 +9,10 @@ export default {
   component: Paragraph,
 };
 
-export function Size() {
+export function Size({ args }) {
   return (
     <Layout.StoryVertical>
-      <Paragraph size="1" format="basic">
+      <Paragraph size="1" format="basic" {...args}>
         Paragraph Size 1.
         <br />
         Lorem ipsum, dolor sit amet consectetur adipisicing elit.
@@ -54,10 +54,10 @@ export function Size() {
 }
 Size.storyName = 'size';
 
-export function Format() {
+export function Format({ args }) {
   return (
     <Layout.StoryVertical>
-      <Paragraph size="2">
+      <Paragraph size="2" {...args}>
         Paragraph Size 2.
         <br />
         Lorem ipsum, dolor sit amet consectetur adipisicing elit.
@@ -89,10 +89,10 @@ export function Format() {
 }
 Format.storyName = 'format';
 
-export function Status() {
+export function Status({ args }) {
   return (
     <Layout.StoryVertical>
-      <Paragraph size="2">
+      <Paragraph size="2" {...args}>
         Paragraph Size 2.
         <br />
         Lorem ipsum, dolor sit amet consectetur adipisicing elit.

--- a/src/typography/Text/Text.examples.story.tsx
+++ b/src/typography/Text/Text.examples.story.tsx
@@ -33,10 +33,12 @@ const TextMeta = styled(Text)`
   letter-spacing: -0.075rem;
 `;
 
-export function HeavyText() {
+export function HeavyText({ args }) {
   return (
     <Layout.StoryVertical>
-      <TextHeavy format="basic">Text Primitive Component</TextHeavy>
+      <TextHeavy {...args} format="basic">
+        Text Primitive Component
+      </TextHeavy>
       <TextHeavy format="soft">Text Primitive Component</TextHeavy>
       <TextHeavy format="alternative">
         Text Primitive Component
@@ -56,10 +58,12 @@ export function HeavyText() {
 }
 HeavyText.storyName = 'custom (heavy)';
 
-export function ThinText() {
+export function ThinText({ args }) {
   return (
     <Layout.StoryVertical>
-      <TextThin format="basic">Text Primitive Component</TextThin>
+      <TextThin format="basic" {...args}>
+        Text Primitive Component
+      </TextThin>
       <TextThin format="soft">Text Primitive Component</TextThin>
       <TextThin format="alternative">
         Text Primitive Component

--- a/src/typography/Text/Text.props.story.tsx
+++ b/src/typography/Text/Text.props.story.tsx
@@ -12,7 +12,7 @@ export default {
   component: Text,
 };
 
-export function Size() {
+export function Size({ args }) {
   return (
     <Layout.StoryVertical>
       {[...new Array(11)].map((_, i) => {
@@ -22,7 +22,7 @@ export function Size() {
 
         return (
           <Row key={i}>
-            <Text size={grade}>
+            <Text size={grade} {...args}>
               size-{grade} • {unitPx}px • {unitRem}
             </Text>
           </Row>
@@ -33,10 +33,10 @@ export function Size() {
 }
 Size.storyName = 'size';
 
-export function Editable() {
+export function Editable({ args }) {
   return (
     <Layout.StoryVertical>
-      <Row>
+      <Row {...args}>
         <Text placeholder="Edit me!" contentEditable>
           Text Primitive Component
         </Text>

--- a/src/utils/hooks/useMeasure.story.tsx
+++ b/src/utils/hooks/useMeasure.story.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 export default { title: 'utilties/useMeasure' };
 
 export const Common = () => <CommonStory />;
+
 function CommonStory() {
   const [button, DOMRect] = useMeasure(<Button>Button</Button>);
   const { width, height } = DOMRect;


### PR DESCRIPTION
This PR updates all stories that do not render code snippets in docs. 

**How it does that:** 
Adds `{args}` to exported story functions, this is needed for storybook's doc block Source: https://storybook.js.org/docs/ember/writing-docs/doc-block-source

**Next steps**
Docs for Dates components should be resolved, positioning of element blocks source snippets
Add MDX docx page and ability to add custom stories for developer docs