### PR TITLE
Add styling for disabled menu item

### DIFF
--- a/src/components/Menu/Menu.examples.story.tsx
+++ b/src/components/Menu/Menu.examples.story.tsx
@@ -131,3 +131,29 @@ const PopList = (
     </Pop.List>
   </>
 );
+
+export function WithDisabledItems({ args }) {
+  return (
+    <Layout.StoryVertical>
+      <Menu style={{ padding: '1rem' }} {...args}>
+        <Menu.Section title="Section 1">
+          <Menu.Item active icon={<Home />}>
+            <Header size="4">Can be any element</Header>
+          </Menu.Item>
+          <Menu.Item href="#" icon={<Gear />}>
+            With href
+          </Menu.Item>
+        </Menu.Section>
+
+        <Menu.Section title="Section 2">
+          <Menu.Item disabled icon={<Folder />}>
+            Item 1 Disabled
+          </Menu.Item>
+          <Menu.Item disabled icon={<Grid />}>
+            Item 2 Disabled
+          </Menu.Item>
+        </Menu.Section>
+      </Menu>
+    </Layout.StoryVertical>
+  );
+}

--- a/src/components/Menu/Menu.style.ts
+++ b/src/components/Menu/Menu.style.ts
@@ -2,6 +2,7 @@ import styled, { css, keyframes } from 'styled-components';
 import { rgba } from 'polished';
 
 import { grayscale, slate } from '../../color';
+import { core } from '../../tokens';
 
 export const Action = styled.button`
   position: absolute;
@@ -113,7 +114,7 @@ export const ItemStyled = styled.button<any>`
   font-size: 0.875rem;
   width: 100%;
   background: transparent;
-  color: ${({ theme }) => theme.content.color};
+  color: ${core.color.text(0)};
   border: 0;
   cursor: pointer;
 
@@ -123,6 +124,13 @@ export const ItemStyled = styled.button<any>`
 
   &:focus {
     outline: none;
+  }
+
+  &:disabled {
+    color: ${core.color.text(600)};
+    opacity: 0.5;
+    pointer-events: none;
+    user-select: none;
   }
 
   > svg {


### PR DESCRIPTION
This PR adds styling when the `disabled` property is passed to the `Menu.Item`.

Example story: https://vimeo.github.io/iris/sb/menu-item-disabled/?path=/story/components-menu-examples--with-disabled-items