### PR TITLE
Avoid empty onchange event in Date Range 

### DIFF
--- a/src/components/inputs/Dates/DateRange/DateRange.story.tsx
+++ b/src/components/inputs/Dates/DateRange/DateRange.story.tsx
@@ -84,13 +84,8 @@ function DateRangeButton({ ...args }) {
   const [active, setActive] = useState(false);
 
   const onChange = (range: [Date, Date]) => {
-    const validRange = range[0] && range[1];
-
-    if (validRange && range !== value) {
-      setValue(range);
-      setActive(false);
-    }
-    if (!validRange) setValue(null);
+    setValue(range);
+    setActive(false);
   };
 
   const childrenRef =

--- a/src/components/inputs/Dates/DateRange/DateRange.tsx
+++ b/src/components/inputs/Dates/DateRange/DateRange.tsx
@@ -4,6 +4,7 @@ import React, {
   useMemo,
   useReducer,
   useState,
+  useRef,
 } from 'react';
 
 import { Calendar } from '../Calendar/Calendar';
@@ -52,6 +53,8 @@ function DateRangeComponent({
   translation = translations['en'],
   defaultValue,
 }: Props) {
+  const firstRender = useRef(true);
+
   const initial = defaultValue
     ? {
         ...initialState,
@@ -66,8 +69,10 @@ function DateRangeComponent({
   // When our internal range value changes, if a callback for onChange is passed
   // let's call that callback with our new value.
   useEffect(() => {
-    if (onChange) {
+    if (onChange && !firstRender.current) {
       onChange(state.range);
+    } else {
+      firstRender.current = false;
     }
   }, [state.range, onChange]);
 


### PR DESCRIPTION
Hey.

The problem in Date Range  is that it fires `onChange` callback after first render with empty data, but it should fires it only after confirm the calendar. That is why users of the component have to use a lot of additional `ifelse` checks.

My code prevents first invoke of `onChange`, and this resolves all issues. 

