### PR TITLE
update focus styles for inputs

### DIFF
--- a/src/components/inputs/Input/Text.tsx
+++ b/src/components/inputs/Input/Text.tsx
@@ -110,6 +110,7 @@ export function Text({
         parent={InputStyled}
         radius={pill ? 50 : 6}
         variant={variant}
+        distance={1}
       />
     </div>
   );

--- a/src/components/inputs/Select/Select.tsx
+++ b/src/components/inputs/Select/Select.tsx
@@ -63,7 +63,11 @@ function SelectNative({
         >
           {children}
         </SelectStyled>
-        <Focus parent={SelectStyled} radius={pill ? 50 : 6} />
+        <Focus
+          parent={SelectStyled}
+          radius={pill ? 50 : 6}
+          distance={1}
+        />
         <ChevronDown size={size} />
       </div>
     </Wrapper>

--- a/src/components/inputs/Shared.ts
+++ b/src/components/inputs/Shared.ts
@@ -99,8 +99,6 @@ const underline = css`
   border-top-color: rgba(0, 0, 0, 0);
   border-left-color: rgba(0, 0, 0, 0);
   border-right-color: rgba(0, 0, 0, 0);
-  border-bottom-width: 0.125rem;
-  transition: all 120ms ease-in-out, border 60ms ease-in-out;
 `;
 
 function inputVariant({ variant = null }) {

--- a/src/components/inputs/Slider/Handle.tsx
+++ b/src/components/inputs/Slider/Handle.tsx
@@ -65,7 +65,7 @@ export function Handle({
               onBlur={setFocus(false)}
               focused={focused === handle}
             />
-            <Focus parent={LabelInput} />
+            <Focus parent={LabelInput} distance={1} />
           </>
         ) : (
           formatter(value)

--- a/src/components/inputs/TextArea/TextArea.tsx
+++ b/src/components/inputs/TextArea/TextArea.tsx
@@ -53,7 +53,7 @@ function TextAreaComponent({
           {...props}
         />
         {format === 'negative' ? <InfoIcon /> : null}
-        <Focus parent={TextAreaStyled} />
+        <Focus parent={TextAreaStyled} distance={1} />
       </div>
     </Wrapper>
   );

--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -1,5 +1,5 @@
 import styled, { css, createGlobalStyle } from 'styled-components';
-import { rgba, rem } from 'polished';
+import { rem } from 'polished';
 
 import { blue } from '../color';
 import { IrisTheme } from '../themes';
@@ -21,15 +21,6 @@ export const hidden = {
 
 export const Focus = styled.div<any>`
   ${({ parent, focused, variant, radius = 6, distance = 4 }) => {
-    // These are basically quick hacks to support a different focus
-    // style for the underline inputs until VDS has time to rebuild
-    // the focus component.
-    const focus =
-      variant === 'underline' ? rgba(blue(300), 0.9) : blue(500);
-
-    const expanded =
-      variant === 'underline' ? 'scale(0.975);' : 'scale(1);';
-
     const underline =
       variant === 'underline' &&
       css`
@@ -37,7 +28,6 @@ export const Focus = styled.div<any>`
         border-top-color: rgba(0, 0, 0, 0) !important;
         border-left-color: rgba(0, 0, 0, 0) !important;
         border-right-color: rgba(0, 0, 0, 0) !important;
-        border-bottom-width: ${rem(6)};
       `;
 
     return css`
@@ -48,22 +38,20 @@ export const Focus = styled.div<any>`
       width: calc(100% + ${rem(distance * 2)});
       height: calc(100% + ${rem(distance * 2)});
       pointer-events: none;
-      transform: scale(0.94);
       border-radius: ${rem(radius)};
-      border: ${rem(1)} solid ${rgba(focus, 0)};
+      border: ${rem(2)} solid ${blue(500)};
+      opacity: 0;
       transition: 150ms ease-in-out;
 
       ${parent}:focus > &,
       ${parent}:focus ~ &,
       ${parent}:focus ~ div > & {
-        transform: ${expanded};
-        border: ${rem(2)} solid ${focus};
+        opacity: 1;
       }
 
       ${focused &&
       css`
-        transform: ${expanded};
-        border: ${rem(2)} solid ${focus};
+        opacity: 1;
       `}
 
       ${underline};


### PR DESCRIPTION
Request from design: Update the focus state on the underlined input so that there is no distance between the focus outline and the border.

As part of this change it was decided to remove the distance between the focus outline on all input components. For a11y and visual consistency this change also:
1. reduces the base border on the underline input to 1px
2. uses opacity for the transition rather than transform
