### PR TITLE
Fix ability to handle onBlur as expected

### DIFF
--- a/src/components/inputs/Input/Input.test.tsx
+++ b/src/components/inputs/Input/Input.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import { ThemeProvider } from 'styled-components';
 import { themes } from '../../../themes';
@@ -15,5 +15,17 @@ describe('Input', () => {
     );
     const input = screen.getByTestId('input');
     expect(input).toBeInTheDocument();
+  });
+
+  it('Calls blur function', () => {
+    const mockFn = jest.fn();
+    render(
+      <ThemeProvider theme={themes['light']}>
+        <Input data-testid="input" onBlur={mockFn} />
+      </ThemeProvider>
+    );
+    const input = screen.getByTestId('input');
+    fireEvent.blur(input);
+    expect(mockFn).toBeCalled();
   });
 });

--- a/src/components/inputs/Input/useSuggestions.tsx
+++ b/src/components/inputs/Input/useSuggestions.tsx
@@ -7,21 +7,9 @@ import { Header as H } from '../../../typography';
 import { blue } from '../../../color';
 import { Focus } from '../../../utils';
 
-export function useSuggestions({ autosuggest, inputRef, doBlur }) {
+export function useSuggestions({ autosuggest, onSelect }) {
   if (typeof autosuggest === 'undefined') return;
   if (autosuggest === null) return { has: true, show: false };
-
-  function select(suggestion = null) {
-    if (suggestion) inputRef.current.value = suggestion;
-    inputRef?.current?.focus();
-  }
-
-  function onClick(suggestion) {
-    return (event) => {
-      select(suggestion);
-      doBlur(event);
-    };
-  }
 
   function onKeyDown(suggestion) {
     return (event) => {
@@ -29,13 +17,14 @@ export function useSuggestions({ autosuggest, inputRef, doBlur }) {
 
       switch (event.key) {
         case 'Escape':
-          return select();
+        case 'Tab':
+          return onSelect();
         case 'ArrowDown':
           return event.target?.nextSibling?.focus();
         case 'ArrowUp':
           return event.target?.previousSibling?.focus();
         case 'Enter':
-          return select(suggestion);
+          return onSelect(suggestion);
       }
     };
   }
@@ -44,7 +33,7 @@ export function useSuggestions({ autosuggest, inputRef, doBlur }) {
     <Suggestion
       key={key}
       onKeyDown={onKeyDown(suggestion)}
-      onClick={onClick(suggestion)}
+      onClick={() => onSelect(suggestion)}
     >
       {suggestion}
     </Suggestion>


### PR DESCRIPTION
**Bug**
When passing a function to `onBlur`, of a text input, it doesn't receive the correct event object.

**Expectation**
The (synthetic) event that happens onBlur should be received 

**What this PR does**

- Because of the suggestions feature baked into this component, this PR modifies the `doBlur` and `useSuggestion` hook function to check for a `relatedTarget`.
- Adds a small test for Input component for onBlur fix