### PR TITLE
fixed date range manual input for dd.mm.yyyy

### DIFF
--- a/src/components/inputs/Dates/Calendar/Calendar.state.tsx
+++ b/src/components/inputs/Dates/Calendar/Calendar.state.tsx
@@ -7,6 +7,8 @@ import {
 import {
   getDateFormat,
   getDateFormatRegex,
+  DD_MM_YY_FORMAT,
+  convertDDMMYYYToMMDDYYYY,
 } from '../DateRange/DateFormat';
 
 /**
@@ -92,7 +94,12 @@ export function reducer(state: State, action: Action): State {
         };
       }
 
-      const newStartDate = new Date(label);
+      const newStartDate = new Date(
+        dateFormat === DD_MM_YY_FORMAT
+          ? convertDDMMYYYToMMDDYYYY(label)
+          : label
+      );
+
       const minDate = action.payload.minDate;
       // If the date entered is not a valid date only update the label and set error
       if (isNaN(newStartDate.getTime())) {

--- a/src/components/inputs/Dates/Calendar/Calendar.state.tsx
+++ b/src/components/inputs/Dates/Calendar/Calendar.state.tsx
@@ -8,7 +8,7 @@ import {
   getDateFormat,
   getDateFormatRegex,
   DD_MM_YY_FORMAT,
-  convertDDMMYYYToMMDDYYYY,
+  convertDDMMYYYToYYYYMMDD,
 } from '../DateRange/DateFormat';
 
 /**
@@ -96,7 +96,7 @@ export function reducer(state: State, action: Action): State {
 
       const newStartDate = new Date(
         dateFormat === DD_MM_YY_FORMAT
-          ? convertDDMMYYYToMMDDYYYY(label)
+          ? convertDDMMYYYToYYYYMMDD(label)
           : label
       );
 

--- a/src/components/inputs/Dates/DateRange/DateFormat.ts
+++ b/src/components/inputs/Dates/DateRange/DateFormat.ts
@@ -4,7 +4,14 @@ const DATE_FORMAT_OPTIONS = {
   day: '2-digit',
 } as const;
 
+export const DD_MM_YY_FORMAT = 'DD.MM.YYYY';
 const DEFAULT_LANGUAGE = 'default';
+
+export const convertDDMMYYYToMMDDYYYY = (date: string) => {
+  const dateParts = date.split('.');
+
+  return `${dateParts[2]}.${dateParts[1]}.${dateParts[0]}`;
+};
 
 const formatter = (() => {
   try {

--- a/src/components/inputs/Dates/DateRange/DateFormat.ts
+++ b/src/components/inputs/Dates/DateRange/DateFormat.ts
@@ -7,10 +7,8 @@ const DATE_FORMAT_OPTIONS = {
 export const DD_MM_YY_FORMAT = 'DD.MM.YYYY';
 const DEFAULT_LANGUAGE = 'default';
 
-export const convertDDMMYYYToMMDDYYYY = (date: string) => {
-  const dateParts = date.split('.');
-
-  return `${dateParts[2]}.${dateParts[1]}.${dateParts[0]}`;
+export const convertDDMMYYYToYYYYMMDD = (date: string) => {
+  return date.split('.').reverse().join('.');
 };
 
 const formatter = (() => {

--- a/src/components/inputs/Dates/DateRange/DateFormat.ts
+++ b/src/components/inputs/Dates/DateRange/DateFormat.ts
@@ -6,7 +6,7 @@ const DATE_FORMAT_OPTIONS = {
 
 export const DD_MM_YY_FORMAT = 'DD.MM.YYYY';
 const DEFAULT_LANGUAGE = 'default';
-
+// Converts date to ISO 8601 format for Date constuctor: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
 export const convertDDMMYYYToYYYYMMDD = (date: string) => {
   return date.split('.').reverse().join('.');
 };


### PR DESCRIPTION
connected to https://vimean.atlassian.net/browse/UXE-72

we provide format of date, which a user should use.
https://github.com/vimeo/iris/blob/main/src/components/inputs/Dates/DateRange/DateFormat.ts#L27
https://github.com/vimeo/iris/blob/main/src/components/inputs/Dates/Calendar/Calendar.state.tsx#L87

issue happens when a user should enter  `dd.mm.yyyy` date format - we show him "invalid date error". Because javascript  `new Date `constuction doesn't work with  `dd.mm.yyyy `format

The code checks if date format dd.mm.yyyy - then it transforms the format into yyyy.mm.dd which works with `new Date`