### PR TITLE
allow click dismiss on color select extra space

### DIFF
--- a/src/components/inputs/ColorSelect/ColorSelect.style.ts
+++ b/src/components/inputs/ColorSelect/ColorSelect.style.ts
@@ -24,6 +24,7 @@ export const Wrapper = styled.div<{ width?: number }>`
   position: relative;
   width: ${(p) => p.width}px;
   border-radius: 0.25rem;
+  overflow: hidden;
 `;
 
 export const SpectrumWrapper = styled.div<{ dragging?: boolean }>`


### PR DESCRIPTION
![Screenshot 2022-09-13 at 09 34 52](https://user-images.githubusercontent.com/11707599/190230355-f81eab89-acd1-4a6d-9a29-379dd7dd2099.png)

Color select click area is larger than it should be because of a width on an internal wrapper.

Assuming there is a good reason for that width, I just did an overflow:hidden to fix the large click area.