### PR TITLE
Warn in dev for child validation rather than return null

### DIFF
--- a/src/components/inputs/Checkbox/CheckboxSet.tsx
+++ b/src/components/inputs/Checkbox/CheckboxSet.tsx
@@ -73,8 +73,7 @@ function CheckboxSetComponent({
     checksSet(initialState);
   }, [children, coupled, defaultChecked]);
 
-  if (!validate(children, 'checkbox') && DEV)
-    console.warn('Unable to validate children on CheckboxSet');
+  validate(children, 'checkbox');
 
   const allChecked = checks.every((check) => check);
   const someChecked = !allChecked && checks.some((check) => check);
@@ -127,8 +126,6 @@ function CheckboxSetComponent({
     </div>
   );
 }
-
-const DEV = process.env.NODE_ENV === 'development';
 
 const toggle = (index) => (checked) =>
   checked.map((val, i) => (index === i ? !val : val));

--- a/src/components/inputs/Radio/RadioSet.tsx
+++ b/src/components/inputs/Radio/RadioSet.tsx
@@ -44,7 +44,7 @@ function RadioSetComponent({
     initialCheckedIndex
   );
 
-  if (!validate(children, 'radio')) return null;
+  validate(children, 'radio');
 
   function onChange(event) {
     if (event.target.checked) {

--- a/src/components/inputs/Shared.ts
+++ b/src/components/inputs/Shared.ts
@@ -9,6 +9,8 @@ import { rgba, rem } from 'polished';
 import { blue, white } from '../../color';
 import { Statuses } from '../../themes';
 
+const isDev = process?.env?.NODE_ENV === 'development';
+
 export function inputColors({ theme, disabled = false, format }) {
   if (!format || !theme.formats[format]) format = 'basic';
 
@@ -283,7 +285,7 @@ export function validate(
   const Name = type.charAt(0).toUpperCase() + type.slice(1);
   const valid = children.every(compareMetas(type));
 
-  if (!valid) {
+  if (!valid && isDev) {
     console.warn(
       `<${Name}Set /> children must be <${Name} />.`,
       children


### PR DESCRIPTION
Currently RadioSet will return null based on validation that compares displayName. This causes some issues in production code where the displayName is stripped from the component.

Changing this logic to a warning in dev.