### PR TITLE
Add onClose and onOpen functions to toggled menu items

### DIFF
--- a/src/components/Menu/Menu.examples.story.tsx
+++ b/src/components/Menu/Menu.examples.story.tsx
@@ -39,7 +39,26 @@ export function Simple({ args }) {
     </Layout.StoryVertical>
   );
 }
-
+export function Collapsible({ args }) {
+  return (
+    <Menu style={{ padding: '1rem' }} {...args}>
+      <Menu.Section title="Section 1">
+        <Menu.Item
+          toggle
+          onOpen={() => console.log('onOpen')}
+          onClose={() => console.log('onClose')}
+        >
+          Item 1 S1
+          <Menu.Item>Item 1 S1 SubItem 1</Menu.Item>
+          <Menu.Item>Item 1 S1 SubItem 2</Menu.Item>
+          <Menu.Item>Item 1 S1 SubItem 3</Menu.Item>
+          <Menu.Item>Item 1 S1 SubItem 4</Menu.Item>
+        </Menu.Item>
+        <Menu.Item>Item 2 S1</Menu.Item>
+      </Menu.Section>
+    </Menu>
+  );
+}
 export function Complex({ args }) {
   return (
     <Layout.StoryVertical>

--- a/src/components/Menu/Menu.minors.tsx
+++ b/src/components/Menu/Menu.minors.tsx
@@ -1,4 +1,9 @@
-import React, { useState, MouseEvent } from 'react';
+import React, {
+  useState,
+  MouseEvent,
+  useEffect,
+  useRef,
+} from 'react';
 
 import {
   Header,
@@ -33,9 +38,23 @@ export function Item({
   href,
   toggle = false,
   icon,
+  /** Function called if item is toggled open */
+  onOpen,
+  /** Function called if item is toggled close */
+  onClose,
   ...props
 }) {
+  const init = useRef(true);
   const [open, setOpen] = useState(!toggle);
+
+  useEffect(() => {
+    // Prevent calling onClose on mount
+    if (init.current) {
+      init.current = false;
+    } else {
+      open ? onOpen && onOpen() : onClose && onClose();
+    }
+  }, [onClose, onOpen, open]);
 
   const doToggle = () => toggle && setOpen((open) => !open);
 

--- a/src/components/Menu/Menu.minors.tsx
+++ b/src/components/Menu/Menu.minors.tsx
@@ -51,8 +51,10 @@ export function Item({
     // Prevent calling onClose on mount
     if (init.current) {
       init.current = false;
+    } else if (open) {
+      onOpen?.();
     } else {
-      open ? onOpen && onOpen() : onClose && onClose();
+      onClose?.();
     }
   }, [onClose, onOpen, open]);
 


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Adds `onClose` and `onOpen` functions to the toggled menu item.

## Testing <!-- instructions on how to test -->
[Storybook](https://vimeo.github.io/iris/sb/menuItem-toggle-functions/?path=/story/components-menu-examples--collapsible): confirm that `onClose` and `onOpen` can be read in the console when opening and closing item.
