### PR TITLE
Toggle menu item refactor for focus state

### DIFF
--- a/src/components/Menu/Menu.examples.story.tsx
+++ b/src/components/Menu/Menu.examples.story.tsx
@@ -41,22 +41,47 @@ export function Simple({ args }) {
 }
 export function Collapsible({ args }) {
   return (
-    <Menu style={{ padding: '1rem' }} {...args}>
-      <Menu.Section title="Section 1">
-        <Menu.Item
-          toggle
-          onOpen={() => console.log('onOpen')}
-          onClose={() => console.log('onClose')}
-        >
-          Item 1 S1
-          <Menu.Item>Item 1 S1 SubItem 1</Menu.Item>
-          <Menu.Item>Item 1 S1 SubItem 2</Menu.Item>
-          <Menu.Item>Item 1 S1 SubItem 3</Menu.Item>
-          <Menu.Item>Item 1 S1 SubItem 4</Menu.Item>
-        </Menu.Item>
-        <Menu.Item>Item 2 S1</Menu.Item>
-      </Menu.Section>
-    </Menu>
+    <>
+      <Menu style={{ padding: '1rem' }} {...args}>
+        <Menu.Section title="Section 1">
+          <Menu.Item
+            toggle
+            onOpen={() => console.log('onOpen')}
+            onClose={() => console.log('onClose')}
+          >
+            Item 1 S1
+            <Menu.Item>Item 1 S1 Subitem 1</Menu.Item>
+            <Menu.Item>Item 1 S1 SubItem 2</Menu.Item>
+            <Menu.Item>Item 1 S1 SubItem 3</Menu.Item>
+            <Menu.Item>Item 1 S1 SubItem 4</Menu.Item>
+          </Menu.Item>
+          <Menu.Item>Item 2 S1</Menu.Item>
+          <Menu.Item icon={<Home />}>Item 3 S1</Menu.Item>
+        </Menu.Section>
+      </Menu>
+
+      <Menu style={{ padding: '1rem', marginTop: '1rem' }} {...args}>
+        <Menu.Section title="More Nested Options">
+          <Menu.Item
+            toggle
+            onOpen={() => console.log('onOpen')}
+            onClose={() => console.log('onClose')}
+          >
+            Item 1 S1
+            <Menu.Item toggle>
+              Item 1 S1 Subitem 1
+              <Menu.Item>Item 1 S1 Another Subitem 1</Menu.Item>
+              <Menu.Item>Item 1 S1 Another SubItem 2</Menu.Item>
+              <Menu.Item>Item 1 S1 Another SubItem 3</Menu.Item>
+            </Menu.Item>
+            <Menu.Item>Item 1 S1 SubItem 2</Menu.Item>
+            <Menu.Item>Item 1 S1 SubItem 3</Menu.Item>
+          </Menu.Item>
+          <Menu.Item>Item 2 S1</Menu.Item>
+          <Menu.Item icon={<Home />}>Item 3 S1</Menu.Item>
+        </Menu.Section>
+      </Menu>
+    </>
   );
 }
 export function Complex({ args }) {

--- a/src/components/Menu/Menu.minors.tsx
+++ b/src/components/Menu/Menu.minors.tsx
@@ -12,6 +12,8 @@ import {
   Action,
   Wrapper,
   SubMenu,
+  SvgWrapper,
+  ItemLabel,
 } from './Menu.style';
 
 import { MinorComponent, Focus } from '../../utils';
@@ -83,10 +85,18 @@ export function Item({
     <Wrapper active={active} $height={$height}>
       <ItemStyled
         onClick={doToggle}
-        as={link ? 'a' : 'button'}
+        as={toggle ? 'span' : link ? 'a' : 'button'}
         href={href}
+        hasToggle={toggle}
         {...props}
       >
+        {toggle && (
+          <Toggle open={open} aria-label={`${simpleKids}`}>
+            <ChevronDown />
+            <Focus parent={Toggle} />
+          </Toggle>
+        )}
+
         {action && (
           <Action onClick={doAction}>
             {action.icon}
@@ -94,20 +104,16 @@ export function Item({
           </Action>
         )}
 
-        {icon && icon}
-        {simpleKids}
+        {icon && <SvgWrapper>{icon}</SvgWrapper>}
+        <ItemLabel>{simpleKids}</ItemLabel>
         <Focus parent={ItemStyled} />
       </ItemStyled>
 
-      {toggle && (
-        <Toggle open={open}>
-          <ChevronDown />
-          <Focus parent={Toggle} />
-        </Toggle>
-      )}
       {open && complexKids && (
         <SubMenu total={complexKids.length}>{complexKids}</SubMenu>
       )}
+
+      {/* <Focus parent={toggle ? Toggle : ItemStyled} /> */}
     </Wrapper>
   );
 }

--- a/src/components/Menu/Menu.style.ts
+++ b/src/components/Menu/Menu.style.ts
@@ -25,24 +25,15 @@ export const Action = styled.button`
   }
 `;
 
-export const Toggle = styled.div<{ open?: boolean }>`
+export const Toggle = styled.button<{ open?: boolean }>`
   width: 1.5rem;
   height: 1.5rem;
-  position: absolute;
-  top: 0.5rem;
-  left: -0.5rem;
   transition: 120ms ease-in-out;
 
   transform: ${(p) => (p.open ? 'rotate(0deg)' : 'rotate(-90deg)')};
 
   &:focus {
     outline: none;
-  }
-
-  > svg {
-    * {
-      fill: ${({ theme }) => theme.content.color};
-    }
   }
 `;
 
@@ -90,25 +81,32 @@ export const Wrapper = styled.div<{
       transition: 230ms ease-in-out;
       height: ${(p.$height + 1) * 2.5 + 0.25}rem;
     `}
+`;
+
+export const SvgWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  padding-left: 0.5rem;
 
   > svg {
     width: 1.125rem;
     height: 1.125rem;
-    margin: 0 0.5rem 0 0;
     display: inline-block;
+  }
 
-    * {
-      fill: ${({ theme }) => rgba(theme.content.color, 0.667)};
-    }
+  * {
+    fill: ${({ theme }) => rgba(theme.content.color, 0.667)};
   }
 `;
 
-export const ItemStyled = styled.button<any>`
-  padding: 0.5rem 1.25rem;
+export const ItemStyled = styled.button<{ hasToggle?: boolean }>`
+  padding: ${(p) =>
+    p.hasToggle ? '0.5rem 1.25rem 0.5rem 0' : '0.5rem 1.5rem'};
   display: flex;
   flex-wrap: wrap;
   position: relative;
   align-items: center;
+  align-content: center;
   line-height: 1.5rem;
   border-radius: 0.2rem;
   font-size: 0.875rem;
@@ -132,16 +130,10 @@ export const ItemStyled = styled.button<any>`
     pointer-events: none;
     user-select: none;
   }
+`;
 
-  > svg {
-    width: 1.125rem;
-    height: 1.125rem;
-    margin-right: 1rem;
-
-    * {
-      fill: ${({ theme }) => rgba(theme.content.color, 0.667)};
-    }
-  }
+export const ItemLabel = styled.span`
+  padding-left: 0.5rem;
 `;
 
 export const MenuStyled = styled.div<{
@@ -162,17 +154,18 @@ export const MenuStyled = styled.div<{
 export const SubMenu = styled.div<{ total: number }>`
   width: 100%;
   padding-top: 0.25rem;
+  padding-left: 1rem;
 
   > div {
     animation: ${fade} 120ms ease-in-out both;
-
-    ${(p) =>
-      [...new Array(30)].map(
-        (_, i) => css`
-          &:nth-child(${i}) {
-            animation-delay: ${i * (20 + 100 / p.total)}ms;
-          }
-        `
-      )};
   }
+
+  ${(p) =>
+    [...new Array(30)].map(
+      (_, i) => css`
+        > :nth-child(${i}) {
+          animation-delay: ${i * (20 + 100 / p.total)}ms;
+        }
+      `
+    )};
 `;


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Still a WIP to account for menu height when submenu has been opened.

***Breaking Change***

- Updates the focus state for the toggled menu item
- Adds a little bit of sensible semantic elements for accessibility

 
## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->

## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->
There's some significant CSS and HTML elements that have been moved around

## Testing <!-- instructions on how to test -->
[Storybook](https://vimeo.github.io/iris/sb/UXE-94-menu-focus-state/?path=/story/components-menu-examples--collapsible) confirm that focus state works as expected.
