### PR TITLE
Update toggle button and focus state

### DIFF
--- a/src/components/Menu/Menu.minors.tsx
+++ b/src/components/Menu/Menu.minors.tsx
@@ -90,19 +90,19 @@ export function Item({
         {action && (
           <Action onClick={doAction}>
             {action.icon}
-            <Focus parent={Action} />
+            <Focus parent={Action} isKeyboardOnly />
           </Action>
         )}
 
         {icon && icon}
         {simpleKids}
-        <Focus parent={ItemStyled} />
+        <Focus parent={ItemStyled} isKeyboardOnly />
       </ItemStyled>
 
       {toggle && (
         <Toggle open={open}>
           <ChevronDown />
-          <Focus parent={Toggle} />
+          <Focus parent={Toggle} isKeyboardOnly />
         </Toggle>
       )}
       {open && complexKids && (

--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -20,7 +20,14 @@ export const hidden = {
 };
 
 export const Focus = styled.div<any>`
-  ${({ parent, focused, variant, radius = 6, distance = 4 }) => {
+  ${({
+    parent,
+    focused,
+    variant,
+    radius = 6,
+    distance = 4,
+    isKeyboardOnly = false,
+  }) => {
     const underline =
       variant === 'underline' &&
       css`
@@ -29,6 +36,10 @@ export const Focus = styled.div<any>`
         border-left-color: rgba(0, 0, 0, 0) !important;
         border-right-color: rgba(0, 0, 0, 0) !important;
       `;
+
+    const focusPseudoSelector = isKeyboardOnly
+      ? ':focus-visible'
+      : ':focus';
 
     return css`
       z-index: 1;
@@ -43,9 +54,9 @@ export const Focus = styled.div<any>`
       opacity: 0;
       transition: 150ms ease-in-out;
 
-      ${parent}:focus > &,
-      ${parent}:focus ~ &,
-      ${parent}:focus ~ div > & {
+      ${parent}${focusPseudoSelector} > &,
+      ${parent}${focusPseudoSelector} ~ &,
+      ${parent}${focusPseudoSelector} ~ div > & {
         opacity: 1;
       }
 


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Updates the focus state for the menu item

## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->
Adds a `isKeyboardOnly` prop to the <Focus/> component and adds a `:focus-visible` or `:focus` pseudo selector.

## Testing <!-- instructions on how to test -->

[Collapsible menu](https://vimeo.github.io/iris/sb/UXE-94-menu-focus-state-2/?path=/story/components-menu-examples--collapsible) 
[Complex implementation](https://vimeo.github.io/iris/sb/UXE-94-menu-focus-state-2/?path=/story/components-menu-examples--complex)
Confirm that tabbing/clicking focus states work as expected. 