### PR TITLE
menu focus on keyboard only

### DIFF
--- a/src/components/Menu/Menu.minors.tsx
+++ b/src/components/Menu/Menu.minors.tsx
@@ -90,19 +90,19 @@ export function Item({
         {action && (
           <Action onClick={doAction}>
             {action.icon}
-            <Focus parent={Action} />
+            <Focus parent={Action} isKeyboardOnly />
           </Action>
         )}
 
         {icon && icon}
         {simpleKids}
-        <Focus parent={ItemStyled} />
+        <Focus parent={ItemStyled} isKeyboardOnly />
       </ItemStyled>
 
       {toggle && (
         <Toggle open={open}>
           <ChevronDown />
-          <Focus parent={Toggle} />
+          <Focus parent={Toggle} isKeyboardOnly />
         </Toggle>
       )}
       {open && complexKids && (

--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -20,7 +20,14 @@ export const hidden = {
 };
 
 export const Focus = styled.div<any>`
-  ${({ parent, focused, variant, radius = 6, distance = 4 }) => {
+  ${({
+    parent,
+    focused,
+    variant,
+    radius = 6,
+    distance = 4,
+    isKeyboardOnly = false,
+  }) => {
     const underline =
       variant === 'underline' &&
       css`
@@ -29,6 +36,8 @@ export const Focus = styled.div<any>`
         border-left-color: rgba(0, 0, 0, 0) !important;
         border-right-color: rgba(0, 0, 0, 0) !important;
       `;
+
+    const pseudoSelector = isKeyboardOnly ? 'focus-visible' : 'focus';
 
     return css`
       z-index: 1;
@@ -43,9 +52,9 @@ export const Focus = styled.div<any>`
       opacity: 0;
       transition: 150ms ease-in-out;
 
-      ${parent}:focus > &,
-      ${parent}:focus ~ &,
-      ${parent}:focus ~ div > & {
+      ${parent}:${pseudoSelector} > &,
+      ${parent}:${pseudoSelector} ~ &,
+      ${parent}:${pseudoSelector} ~ div > & {
         opacity: 1;
       }
 


### PR DESCRIPTION
Add ability for <Focus> component to focus on keyboard events only and not clicks. Specifically for Menu, but can be added elsewhere.
