### PR TITLE
Fix color select reset button

### DIFF
--- a/src/components/inputs/ColorSelect/ColorSelectInput.tsx
+++ b/src/components/inputs/ColorSelect/ColorSelectInput.tsx
@@ -52,18 +52,19 @@ export function ColorSelectInput({
         }}
       >
         <Dot style={{ background: HEX }} />
-        {reset.label && HEX !== reset.color.toLowerCase() && (
-          <InnerButton
-            format="basic"
-            variant="minimalTransparent"
-            size={size}
-            onClick={resetValues}
-            tooltipText={reset.label}
-            height={height}
-          >
-            <History style={{ opacity: 0.5 }} />
-          </InnerButton>
-        )}
+        {reset.label &&
+          HEX.toLowerCase() !== reset.color.toLowerCase() && (
+            <InnerButton
+              format="basic"
+              variant="minimalTransparent"
+              size={size}
+              onClick={resetValues}
+              tooltipText={reset.label}
+              height={height}
+            >
+              <History style={{ opacity: 0.5 }} />
+            </InnerButton>
+          )}
       </Input>
     </div>
   );


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
added
HEX.toLowerCase() !== reset.color.toLowerCase() 

because HEX value is uppercased

this cause problem: reset button shows even if value and reset colors are equal.
<img width="277" alt="image" src="https://user-images.githubusercontent.com/24543049/204294163-77b5117d-757d-4c71-891e-c3000b099595.png">


## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->

## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->

## Testing <!-- instructions on how to test -->

