### PR TITLE
Tourpoint-types export

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ export default (args) => {
 
   /** @type {import('rollup').RollupOptions} */
   let config = {
-    input: './src/!(_docs|_labs|_process|storybook)*/**/!(*.story.tsx|*.test.ts|*.types.ts)',
+    input: './src/!(_docs|_labs|_process|storybook)*/**/!(*.story.tsx|*.test.ts)',
     output: [
       {
         dir: 'build',

--- a/src/components/TourPoint/TourPoint.types.ts
+++ b/src/components/TourPoint/TourPoint.types.ts
@@ -4,8 +4,8 @@ import {
   ReactNode,
   MouseEvent,
 } from 'react';
-
 export interface Props {
+  id?: string;
   active?: boolean;
   /**
    * Sets or retrieves a text alternative to the graphic.
@@ -27,7 +27,7 @@ export interface Props {
    * The address or URL of the a media resource that is to be considered.
    */
   src?: HTMLImageElement['src'];
-  step: number;
+  step?: number | null;
   style?: CSSProperties;
   title?: HTMLElement['title'];
   getStepsTranslation?: ({


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->

- Updates Tourpoint type: adds `id?: string` and updates `step?: number | null`
- Removes `types.ts` from rollup.config.js 

## Testing <!-- instructions on how to test -->
Checkout this branch, run `pnpm build`, and confirm that types have been generated in build folder.
