### PR TITLE
Revert type export

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ export default (args) => {
 
   /** @type {import('rollup').RollupOptions} */
   let config = {
-    input: './src/!(_docs|_labs|_process|storybook)*/**/!(*.story.tsx|*.test.ts)',
+    input: './src/!(_docs|_labs|_process|storybook)*/**/!(*.story.tsx|*.test.ts|*.types.ts)',
     output: [
       {
         dir: 'build',


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Reverts the ts export implemented in https://github.com/vimeo/iris/commit/b4640be42a3875f98e764ed548bd26c09960dd38#diff-6814bf77564b4f1c92f5861e184e28fe217c080a047fefa8b73a728f755ec45cL16 as it breaks many type checks in our main repo. 


