### PR TITLE
Move carat inside menu.item button

### DIFF
--- a/src/components/Menu/Menu.minors.tsx
+++ b/src/components/Menu/Menu.minors.tsx
@@ -82,11 +82,17 @@ export function Item({
   return (
     <Wrapper active={active} $height={$height}>
       <ItemStyled
-        onClick={doToggle}
         as={link ? 'a' : 'button'}
         href={href}
+        onClick={doToggle}
         {...props}
       >
+        {toggle && (
+          <Toggle open={open}>
+            <ChevronDown />
+            <Focus parent={Toggle} isKeyboardOnly />
+          </Toggle>
+        )}
         {action && (
           <Action onClick={doAction}>
             {action.icon}
@@ -98,13 +104,6 @@ export function Item({
         {simpleKids}
         <Focus parent={ItemStyled} isKeyboardOnly />
       </ItemStyled>
-
-      {toggle && (
-        <Toggle open={open}>
-          <ChevronDown />
-          <Focus parent={Toggle} isKeyboardOnly />
-        </Toggle>
-      )}
       {open && complexKids && (
         <SubMenu total={complexKids.length}>{complexKids}</SubMenu>
       )}

--- a/src/components/Menu/Menu.style.ts
+++ b/src/components/Menu/Menu.style.ts
@@ -30,6 +30,7 @@ export const Toggle = styled.div<{ open?: boolean }>`
   height: 1.5rem;
   position: absolute;
   top: 0.5rem;
+  left: -0.1rem;
   transition: 120ms ease-in-out;
 
   transform: ${(p) => (p.open ? 'rotate(0deg)' : 'rotate(-90deg)')};


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->

Moves the toggle carat inside of menu.item button so clicking on the carat also triggers the opening of the menu.

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->
Before: 
https://user-images.githubusercontent.com/22207955/208742443-2d2060fd-a6e7-4d78-91db-4e9150979844.mov

After:
https://user-images.githubusercontent.com/22207955/208742481-88f215ec-4ae9-46ab-8bb2-fe23b1b4e2ca.mov

