### PR TITLE
Replaces The `useLayoutEffect` With `useIsomorphicEffect` in `useAnimations` To Support Server Rendering

### DIFF
--- a/src/utils/hooks/usePortal_DEPRECATED/useMountAnimations.ts
+++ b/src/utils/hooks/usePortal_DEPRECATED/useMountAnimations.ts
@@ -1,9 +1,10 @@
-import { useState, useLayoutEffect, useMemo, useRef } from 'react';
+import { useState, useMemo, useRef } from 'react';
 
 import { PortalConfig } from './usePortal_DEPRECATED.types';
 
 import { onEvent } from '../../events';
 import { getComputedStyles, animate } from '../../DOM';
+import { useIsomorphicEffect } from '../useIsomorphicEffect';
 
 const initialState = {
   active: false,
@@ -29,7 +30,7 @@ export function useMountAnimations(
   const controlled = forceActive === true || forceActive === false;
   const forcedClose = !forceActive && lastForceActive.current;
 
-  useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     if (element) {
       const curDuration = parseFloat(
         getComputedStyles(element, ['animation-duration'])[
@@ -55,7 +56,7 @@ export function useMountAnimations(
     [duration]
   );
 
-  useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     if (!controlled && element && exiting) {
       animateExit(childRef, animation);
       if (screen) animateExit(screenRef, defaultAnimation);


### PR DESCRIPTION
## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
The Video Library page in the Next app logged an error to the console about a `useLayoutEffect` being run on the server. One of the components rendered is the `Modal` component, which uses the `useMountAnimations` hook, which uses `useLayoutEffect`.

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->

| Error | No Error  |
|-------|-------|
| <img width="865" alt="Screenshot 2023-01-27 at 12 20 52 PM" src="https://user-images.githubusercontent.com/77157695/215157782-a77c68a4-48e8-4dff-89b0-3beaa456a5a1.png"> | <img width="997" alt="Screenshot 2023-01-27 at 12 19 42 PM" src="https://user-images.githubusercontent.com/77157695/215158652-e8adc938-f2a1-4c37-9d38-5fea371d6c43.png"> |

## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->
Replaced all `useLayoutEffect` hooks with `useIsomorphicEffect`.

## Testing <!-- instructions on how to test -->

