### PR TITLE
Add dragging to useLayoutEffect dependency array in Slider and add sl…

### DIFF
--- a/src/components/inputs/Slider/Handle.tsx
+++ b/src/components/inputs/Slider/Handle.tsx
@@ -36,7 +36,7 @@ export function Handle({
   return (
     <HandleStyled
       focused={focused === handle || dragging === handle}
-      style={{ left: value + '%' }}
+      style={{ left: (value / max) * 100 + '%' }}
       onMouseDown={() => !disabled && setDragging(handle)}
       {...props}
     >

--- a/src/components/inputs/Slider/Slider.props.story.tsx
+++ b/src/components/inputs/Slider/Slider.props.story.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Slider } from './Slider';
 
 import { Layout } from '../../../storybook';
+import { PopOver } from '../../PopOver/PopOver';
+import { Button } from '../../Button/Button';
 
 export default {
   title: 'components/Slider/props',
@@ -60,3 +62,42 @@ export function EditableLabel({ args }) {
   );
 }
 EditableLabel.storyName = 'EditableLabel';
+
+export function InPopover({ ...args }) {
+  const [active, setActive] = useState(false);
+  return (
+    <Layout.StoryPadded>
+      <Slider editableLabel />
+      <Slider {...args} editableLabel range />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <PopOver
+          active={active}
+          attach="bottom"
+          content={PopOverContent}
+        >
+          <Button onClick={() => setActive(!active)}>
+            Open PopOver
+          </Button>
+        </PopOver>
+      </div>
+    </Layout.StoryPadded>
+  );
+}
+
+const PopOverContent = (
+  <div
+    style={{
+      width: '500px',
+      height: '400px',
+      padding: '3rem',
+    }}
+  >
+    <Slider editableLabel range />
+  </div>
+);

--- a/src/components/inputs/Slider/Slider.props.story.tsx
+++ b/src/components/inputs/Slider/Slider.props.story.tsx
@@ -68,7 +68,15 @@ export function InPopover({ ...args }) {
   return (
     <Layout.StoryPadded>
       <Slider editableLabel />
-      <Slider {...args} editableLabel range />
+      <Slider initialValues={[40, 100]} />
+      <Slider
+        {...args}
+        editableLabel
+        range
+        initialValues={[177, 200]}
+        max={200}
+        min={0}
+      />
       <div
         style={{
           display: 'flex',
@@ -82,7 +90,7 @@ export function InPopover({ ...args }) {
           content={PopOverContent}
         >
           <Button onClick={() => setActive(!active)}>
-            Open PopOver
+            Open Popover with Sliders
           </Button>
         </PopOver>
       </div>
@@ -98,6 +106,14 @@ const PopOverContent = (
       padding: '3rem',
     }}
   >
-    <Slider editableLabel range />
+    <Slider editableLabel />
+    <Slider initialValues={[40, 100]} />
+    <Slider
+      editableLabel
+      range
+      initialValues={[177, 200]}
+      max={200}
+      min={0}
+    />
   </div>
 );

--- a/src/components/inputs/Slider/Slider.style.ts
+++ b/src/components/inputs/Slider/Slider.style.ts
@@ -72,14 +72,15 @@ export const Background = styled.div`
   border-radius: 0.125rem;
 `;
 
-export const ActiveRange = styled.div.attrs<{ values?: number[] }>(
-  ({ values }) => ({
-    style: {
-      width: values[1] - values[0] + '%',
-      left: values[0] + '%',
-    },
-  })
-)<{ values?: number[] }>`
+export const ActiveRange = styled.div.attrs<{
+  values?: number[];
+  max?: number;
+}>(({ values, max }) => ({
+  style: {
+    width: ((values[1] - values[0]) / max) * 100 + '%',
+    left: (values[0] / max) * 100 + '%',
+  },
+}))<{ values?: number[]; max?: number }>`
   pointer-events: none;
   position: absolute;
   height: 100%;

--- a/src/components/inputs/Slider/Slider.tsx
+++ b/src/components/inputs/Slider/Slider.tsx
@@ -67,7 +67,7 @@ export function Slider({
   useLayoutEffect(() => {
     const { left, width } = geometry(ref.current);
     dispatch({ type: 'SET_TRACK_RECT', payload: { left, width } });
-  }, []);
+  }, [dragging]);
 
   useEffect(() => {
     const mouseup = () => dragging && setDragging(false);

--- a/src/components/inputs/Slider/Slider.tsx
+++ b/src/components/inputs/Slider/Slider.tsx
@@ -94,7 +94,7 @@ export function Slider({
 
   return (
     <div {...props} style={{ color: white, margin: '4rem 0' }}>
-      <Track ref={ref} values={values} id="track-1">
+      <Track ref={ref} values={values} id="track-1" max={max}>
         <Handle
           disabled={disabled}
           dragging={dragging}
@@ -138,14 +138,15 @@ interface TrackProps {
   id?: string;
   ref: Ref<HTMLDivElement>;
   values: number[];
+  max: number;
 }
 
 const Track = forwardRef(
-  ({ children, values, ...props }: TrackProps, ref) => {
+  ({ children, values, max, ...props }: TrackProps, ref) => {
     return (
       <Background ref={ref} {...props}>
         {children}
-        <ActiveRange values={values}></ActiveRange>
+        <ActiveRange values={values} max={max}></ActiveRange>
       </Background>
     );
   }
@@ -153,7 +154,7 @@ const Track = forwardRef(
 
 function constrainedPosition(event, element, min, max) {
   const left = event.clientX - element.left;
-  const pos = Math.round((left / element.width) * 100);
+  const pos = Math.round((left / element.width) * max);
 
   return constrain(min, max)(pos);
 }


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->

- Adds `dragging` to `useLayoutEffect` in Slider component to account for positioning in a popover
- Adds a story "In Popover" to show different sliders in a popover.
- Adds `max` value to active range and handle style to account for max values > 100

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->

https://user-images.githubusercontent.com/22207955/218542447-cdc52acf-529f-4aaa-a243-d1df14136f53.mov


## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->

- Includes max value in calculating position of handle and ActiveRange bar (in case user uses a max value > 100)
- Adds `dragging` to dependency array of `useLayoutEffect` to watch for position of `trackRef`

## Testing <!-- instructions on how to test -->
[See storybook](https://vimeo.github.io/iris/sb/fix-slider/?path=/story/components-slider-props--in-popover): Confirm that dragging handle works as expected.
