### PR TITLE
Don't Forward `format` Prop To The Button DOM Element

### DIFF
--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -40,7 +40,9 @@ export const ButtonChildren = styled.span<any>`
     `}
 `;
 
-export const ButtonStyled = styled.button<any>`
+export const ButtonStyled = styled.button.withConfig<any>({
+  shouldForwardProp: (prop: any) => !['format'].includes(prop),
+})`
   ${buttonCore};
   ${buttonIcon};
   ${buttonSizes};


### PR DESCRIPTION
## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Cleans up the button HTML markup by removing `styled-component` specific attributes.

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->

## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->
Uses the `shouldForwardProp` field to prevent the `format` attribute from being passed as a DOM attribute.

## Testing <!-- instructions on how to test -->
N/A
