### PR TITLE
Fix Welcome Story 💐

### DIFF
--- a/src/storybook/welcome/Styles.tsx
+++ b/src/storybook/welcome/Styles.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createGlobalStyle, ThemeProvider } from 'styled-components';
+import { createGlobalStyle, ThemeContext } from 'styled-components';
 import { rgba } from 'polished';
 
 export const GlobalStyles = createGlobalStyle`
@@ -62,7 +62,11 @@ export function Themed({ children }) {
   const current = localStorage.getItem('nox-addon-theme');
   const theme = themes[current];
 
-  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+  return (
+    <ThemeContext.Provider value={theme}>
+      {children}
+    </ThemeContext.Provider>
+  );
 }
 
 export function Styles() {


### PR DESCRIPTION
## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->

<img width="1726" alt="image" src="https://user-images.githubusercontent.com/77157695/218887781-fa6e855a-80b3-48ee-8109-fbb3437fbfb0.png">


## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->
I replaced the `ThemeProvider` component with `ThemeContext.Provider` because inside the `Flowers` component we're accessing the context with `ThemeContext`. It looks like `ThemeProvider` is meant to be used with the `useTheme` hook, I tried that but was running into some type issues, so I abandoned that and went with this.

Edit: I took a look at the styled-components source code and `ThemeProvider`  does wrap its children in the `ThemeContext` so not sure why `name` is undefined here 🤔 
https://github.com/vimeo/iris/blob/2f3f071cde7a57e763006fbafa4516594f86f2d7/src/storybook/welcome/Flower.tsx#L68


