### PR TITLE
Remove Additional Button Props From Being Forwarded

### DIFF
--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -41,7 +41,14 @@ export const ButtonChildren = styled.span<any>`
 `;
 
 export const ButtonStyled = styled.button.withConfig<any>({
-  shouldForwardProp: (prop: any) => !['format'].includes(prop),
+  shouldForwardProp: (prop: any) =>
+    ![
+      'format',
+      'icononly',
+      'iconposition',
+      'theme',
+      'variant',
+    ].includes(prop),
 })`
   ${buttonCore};
   ${buttonIcon};


### PR DESCRIPTION
**Related to:**
https://github.com/vimeo/iris/pull/228

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Adds additional props that should **NOT** forward to the DOM element

<img width="574" alt="image" src="https://user-images.githubusercontent.com/77157695/222200536-72fbd304-4536-4200-b006-558dee3c0aee.png">


## Testing <!-- instructions on how to test -->
N/A
