### PR TITLE
Github workflow to publish package on new version release

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,19 @@
+name: Publish Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          # Setup .npmrc file to publish to npm
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_VIMEO_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -14,6 +14,7 @@ jobs:
           node-version: 14
           # Setup .npmrc file to publish to npm
           registry-url: 'https://registry.npmjs.org'
+      - run: yarn --frozen-lockfile
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_VIMEO_PUBLISH_TOKEN }}


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->

Publishing packages on npm currently requires manual access to be given to the vimeo org in npm. This is problematic from security perspective, because there is no way to automatically remove individuals once they leave Vimeo. There are also issues with maintenance, and legacy knowledge of the process.

This PR adds a GitHub workflow that automates publishing the package to the npm registry through a Vimeo/Devex-maintained npm account. The workflow is triggered by new published version releases. The versioning/release process is largely the same for now, only the final `npm publish` step is automated.

## Testing <!-- instructions on how to test -->

Test workflow: https://github.com/vimeo/iris/blob/publish-package-workflow-test/.github/workflows/publish-package.yml
Test run: https://github.com/vimeo/iris/actions/runs/4358334343/jobs/7618764046
