### PR TITLE
Remove default values from deprecated initialColor and resetColor

### DIFF
--- a/src/components/inputs/ColorSelect/ColorSelect.tsx
+++ b/src/components/inputs/ColorSelect/ColorSelect.tsx
@@ -34,7 +34,7 @@ function ColorSelectComponent({
   initial = { color: '#F00', colorSpace: 'HEX' },
 
   // DEPRECATED
-  initialColor = '#F00',
+  initialColor,
   //
 
   label,
@@ -44,7 +44,7 @@ function ColorSelectComponent({
   reset = { color: initial.color, label: 'reset' },
 
   // DEPRECATED
-  resetColor = initialColor || initial.color,
+  resetColor,
   //
 
   resetLabel,
@@ -67,8 +67,8 @@ function ColorSelectComponent({
   });
 
   // deprecation handling
-  if (initialColor) initial.color = initialColor;
-  if (resetColor) reset.color = resetColor;
+  if (initialColor) initial.color = initialColor || initial.color;
+  if (resetColor) reset.color = resetColor || reset.color;
   if (resetLabel) reset.label = resetLabel;
 
   const defaultColor = parseToHsl(initial.color);


### PR DESCRIPTION
## What this PR does
This PR is fixing a bug where using `initial` prop is being disregarded because `initalColor` has a default value.
Same for `reset` and `resetColor`.

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->
https://user-images.githubusercontent.com/9106375/223707078-5b1856ec-e979-4a67-93a4-3dbbdef653a2.mp4

## How it does that
Removing the default value for the deprecated props and using them as priority if they exist

## Testing
Run storybook and change the story to use another `inital` and `reset`

