### PR TITLE
Publish prerelease workflow

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,0 +1,25 @@
+name: Publish Prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          # Setup .npmrc file to publish to npm
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn --frozen-lockfile
+      - run: npm publish --tag ${{ github.event.inputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_VIMEO_PUBLISH_TOKEN }}


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->

Adds a workflow for publishing prereleases.

## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->

The workflow is manually dispatched instead of being triggered by publishing a release. 
The `publish` job uses the `development` [environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment), which is configured so that jobs using this environment will require approval from the ux-engineering team to run.


