### PR TITLE
Remove hidden input from tabindex

### DIFF
--- a/src/components/inputs/FileUpload/FileUpload.style.ts
+++ b/src/components/inputs/FileUpload/FileUpload.style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
+import { IrisInputProps } from '../../../utils';
 
-export const Hidden = styled.input`
+export const Hidden = styled.input<IrisInputProps>`
   overflow: hidden;
   position: absolute;
   z-index: -1;

--- a/src/components/inputs/FileUpload/FileUpload.tsx
+++ b/src/components/inputs/FileUpload/FileUpload.tsx
@@ -32,6 +32,7 @@ function FileUploadComponent({
       {...props}
     >
       <Hidden
+        tabIndex={-1}
         ref={ref}
         type="file"
         accept={accept}


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Removes hidden input in FileInput from tabindex 

