### PR TITLE
Prevent button props from being added to the DOM element

### DIFF
--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -40,16 +40,7 @@ export const ButtonChildren = styled.span<any>`
     `}
 `;
 
-export const ButtonStyled = styled.button.withConfig<any>({
-  shouldForwardProp: (prop: any) =>
-    ![
-      'format',
-      'icononly',
-      'iconposition',
-      'theme',
-      'variant',
-    ].includes(prop),
-})`
+export const ButtonStyled = styled.button<any>`
   ${buttonCore};
   ${buttonIcon};
   ${buttonSizes};


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->

Cleans up our console!

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->

## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->
Removes the `shouldForwardProp` attribute as it was exposing other props as DOM attributes.

## Testing <!-- instructions on how to test -->

