### PR TITLE
Fix github prerelease version tagging to use npm

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -35,7 +35,7 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - run: pnpm i --frozen-lockfile
-      - run: pnpm version --prerelease --preid=${{ github.event.inputs.preId }} --no-commit-hooks
+      - run: npm version --prerelease --preid=${{ github.event.inputs.preId }} --no-commit-hooks
       - run: npm publish --tag ${{ github.event.inputs.preId }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_VIMEO_PUBLISH_TOKEN }}


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Fixes prerelease github action so prerelease tagging works. (reverting from pnpm migration)

