### PR TITLE
Button keyboard focus only

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -5,7 +5,6 @@ import {
   RenderOptions,
   screen,
 } from '@testing-library/react';
-// import userEvent from '@testing-library/user-event';
 import React, { ReactElement } from 'react';
 
 import { ThemeProvider } from 'styled-components';
@@ -58,6 +57,19 @@ describe('Button', () => {
     expect(button.innerHTML).toContain('svg');
   });
 
+  it('Renders button with icon on the right', () => {
+    renderWithThemeProvider(
+      <Button icon={<Pencil />} iconPosition="right">
+        Hello
+      </Button>
+    );
+
+    const button = screen.getByRole('button');
+    expect(button.children[0].tagName.toLocaleLowerCase()).toBe(
+      'span'
+    );
+  });
+
   it('Renders loader', () => {
     renderWithThemeProvider(<Button loading />);
     const button = screen.getByRole('button');
@@ -104,17 +116,60 @@ describe('Button', () => {
     expect(button).toHaveStyle({ background: '#E22B12' });
   });
 
-  //   it('Shows focus border on focus', async () => {
-  //     const { container } = renderWithThemeProvider(
-  //       <Button isKeyboardOnlyFocus={false} />
-  //     );
+  it('Changes format of a button', () => {
+    const { rerender } = renderWithThemeProvider(
+      <Button format="secondary" />
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveStyle({
+      background: '#efefef',
+    });
 
-  //     const button = screen.getByRole('button');
+    rerender(<Button format="soft" />);
+    expect(button).toHaveStyle({ background: '#23313b' });
+  });
 
-  //     await userEvent.click(button);
+  it('Changes variant of a button', () => {
+    const { rerender } = renderWithThemeProvider(
+      <Button variant="dashed" />
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveStyle({
+      borderStyle: 'dashed',
+    });
 
-  //     const focusWrapper = container.querySelector('div');
+    rerender(<Button variant="hyperminimal" />);
+    expect(button).toHaveStyle({ borderColor: 'transparent' });
+  });
 
-  //     expect(focusWrapper).toHaveStyle({ opacity: 1 });
-  //   });
+  it('Changes element of a button', () => {
+    const { rerender, container } = renderWithThemeProvider(
+      <Button element="a" />
+    );
+    const buttonAnchor = container.querySelector('a');
+    expect(buttonAnchor).toBeInTheDocument();
+
+    rerender(<Button element="span" />);
+    const buttonSpan = container.querySelector('span');
+    expect(buttonSpan).toBeInTheDocument();
+
+    const button = container.querySelector('button');
+    expect(button).not.toBeInTheDocument();
+  });
+
+  it('Renders pill button', () => {
+    renderWithThemeProvider(<Button pill>Hello</Button>);
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveStyle({
+      borderRadius: '2rem',
+    });
+  });
+
+  it('Renders disabled button', () => {
+    renderWithThemeProvider(<Button disabled>Hello</Button>);
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveAttribute('disabled');
+  });
 });

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,0 +1,120 @@
+import '@testing-library/jest-dom';
+import {
+  fireEvent,
+  render,
+  RenderOptions,
+  screen,
+} from '@testing-library/react';
+// import userEvent from '@testing-library/user-event';
+import React, { ReactElement } from 'react';
+
+import { ThemeProvider } from 'styled-components';
+import { Pencil } from '../../icons';
+import { themes } from '../../themes';
+import { Button } from './Button';
+
+const Provider = ({ children }) => {
+  return (
+    <ThemeProvider theme={themes['light']}>{children}</ThemeProvider>
+  );
+};
+
+const renderWithThemeProvider = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) => render(ui, { wrapper: Provider, ...options });
+
+describe('Button', () => {
+  it('Renders button', () => {
+    renderWithThemeProvider(<Button />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('Calls onClick handler when clicked', () => {
+    const handleClick = jest.fn();
+    const { getByText } = renderWithThemeProvider(
+      <Button onClick={handleClick}>Click me</Button>
+    );
+    const buttonElement = getByText('Click me');
+    fireEvent.click(buttonElement);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('Renders button with text child', () => {
+    const text = 'Click me';
+
+    const { getByText } = renderWithThemeProvider(
+      <Button>{text}</Button>
+    );
+
+    const buttonElement = getByText(text);
+    expect(buttonElement).toBeInTheDocument();
+  });
+
+  it('Renders button with icon', () => {
+    renderWithThemeProvider(<Button icon={<Pencil />} />);
+    const button = screen.getByRole('button');
+    expect(button.innerHTML).toContain('svg');
+  });
+
+  it('Renders loader', () => {
+    renderWithThemeProvider(<Button loading />);
+    const button = screen.getByRole('button');
+    expect(button.innerHTML).toContain('Loader');
+  });
+
+  it('Sets color of a button', () => {
+    const color = '#CCCCCC';
+    renderWithThemeProvider(<Button color={color} />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveStyle({ background: color });
+  });
+
+  it('Changes size of a button', () => {
+    const { rerender } = renderWithThemeProvider(
+      <Button size="sm" />
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveStyle({ fontSize: '0.875rem' });
+
+    rerender(<Button size="md" />);
+    expect(button).toHaveStyle({ fontSize: '0.875rem' });
+
+    rerender(<Button size="xs" />);
+    expect(button).toHaveStyle({ fontSize: '0.75rem' });
+
+    rerender(<Button size="lg" />);
+    expect(button).toHaveStyle({ fontSize: '1rem' });
+
+    rerender(<Button size="xl" />);
+    expect(button).toHaveStyle({ fontSize: '1.125rem' });
+  });
+
+  it('Changes status of a button', () => {
+    const { rerender } = renderWithThemeProvider(
+      <Button status="positive" />
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveStyle({
+      background: '#28A878',
+    });
+
+    rerender(<Button status="negative" />);
+    expect(button).toHaveStyle({ background: '#E22B12' });
+  });
+
+  //   it('Shows focus border on focus', async () => {
+  //     const { container } = renderWithThemeProvider(
+  //       <Button isKeyboardOnlyFocus={false} />
+  //     );
+
+  //     const button = screen.getByRole('button');
+
+  //     await userEvent.click(button);
+
+  //     const focusWrapper = container.querySelector('div');
+
+  //     expect(focusWrapper).toHaveStyle({ opacity: 1 });
+  //   });
+});

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -47,6 +47,7 @@ function ButtonComponent({
   theme,
   type,
   variant = 'solid',
+  isKeyboardOnlyFocus = true,
   onClick,
   ...props
 }: Props) {
@@ -111,7 +112,11 @@ function ButtonComponent({
         />
       )}
 
-      <Focus parent={ButtonStyled} radius={radius} />
+      <Focus
+        parent={ButtonStyled}
+        radius={radius}
+        isKeyboardOnly={isKeyboardOnlyFocus}
+      />
     </ButtonStyled>
   );
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -47,7 +47,6 @@ function ButtonComponent({
   theme,
   type,
   variant = 'solid',
-  isKeyboardOnlyFocus = true,
   onClick,
   ...props
 }: Props) {
@@ -112,11 +111,7 @@ function ButtonComponent({
         />
       )}
 
-      <Focus
-        parent={ButtonStyled}
-        radius={radius}
-        isKeyboardOnly={isKeyboardOnlyFocus}
-      />
+      <Focus parent={ButtonStyled} radius={radius} isKeyboardOnly />
     </ButtonStyled>
   );
 }

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -91,13 +91,6 @@ export type Props = IrisProps<
      * [default = 'solid']
      */
     variant?: (typeof variants)[number];
-    /**
-     * Should the focus around the button be only when
-     * focused using a keyboard
-     *
-     * [default = true]
-     */
-    isKeyboardOnlyFocus?: boolean;
   },
   DOMElement
 >;

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -91,6 +91,13 @@ export type Props = IrisProps<
      * [default = 'solid']
      */
     variant?: (typeof variants)[number];
+    /**
+     * Should the focus around the button be only when
+     * focused using a keyboard
+     *
+     * [default = true]
+     */
+    isKeyboardOnlyFocus?: boolean;
   },
   DOMElement
 >;


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does
Changes the default focus UI indication to be on keyboard events only.
Added unit tests for button component.

## Screenshots & Recordings 
https://github.com/vimeo/iris/assets/9106375/3dbcf4a7-3104-414b-b3f4-eea6a64f36ac

## How it does that 
The focus UI itself is being done using a component called `Focus`.
This component has a prop called `isKeyboardOnly` which supports the desired behavior.
Add a prop to button so it can be controlled and set the default to true.

## Testing 
* Click on a button using mouse, validate no focus border.
* Navigate to button using keyboard, validate focus is visible.

![image](https://github.com/vimeo/iris/assets/9106375/132834b1-715c-43df-b1eb-1549ffd9cb11)

## Scanner Report
```
{
  "Button": {
    "instances": 785,
    "props": {
      "onClick": 645, // Tested
      "format": 479, // Tested
      "icon": 283, // Tested
      "size": 258, // Tested
      "variant": 239, // Tested
      "disabled": 175, // Tested
      "fluid": 112, // Cannot be tested no actual width for container and button so width comes as '' instead of 100%
      "data-testid": 69, // not relevant
      "loading": 61, // Tested
      "element": 55, // Tested
      "id": 54, // not relevant
      "iconPosition": 37, // Tested
      "style": 36, // not relevant
      "href": 29, // not relevant
      "status": 26, // Tested
      "ref": 22, // not relevant
      "aria-label": 21, // not relevant
      "className": 19, // not relevant
      "type": 15, // not relevant
      "key": 14, // not relevant
      "theme": 12, // not relevant
      "color": 9, // Tested
      "css": 8, // not relevant
      "pill": 8, // Tested
      "target": 7, // not relevant
      "tabIndex": 4, // not relevant
      "onMouseEnter": 3, // not relevant
      "onMouseLeave": 3, // not relevant
      "children": 2, // Tested
      "data-screen-recorder-cta": 2, // not relevant
      "alt": 1, // not relevant
      "data-js-modalCloseButton": 1, // not relevant
      "floating": 1, // not relevant, used only in 1 place
      "for": 1, // not relevant
      "title": 1 // not relevant
    }
  }
}
```
