### PR TITLE
changed min width of popover component to fit content

### DIFF
--- a/src/components/PopOver/PopOver.style.ts
+++ b/src/components/PopOver/PopOver.style.ts
@@ -18,7 +18,7 @@ const fadeIn = keyframes`
 
 export const PopOverStyled = styled.div<Props>`
   background: ${({ theme }) => theme.content.background};
-  min-width: 10rem;
+  min-width: fit-content;
   min-height: 2rem;
   max-width: 40rem;
   border-radius: 0.25rem;


### PR DESCRIPTION
closes https://vimean.atlassian.net/browse/CEWK-2269
## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
changed popover min width be 'fit-content


