### PR TITLE
WRKFL-2650 - Add Labels to Sidebar Items

### DIFF
--- a/src/components/Sidebar/Sidebar.minors.tsx
+++ b/src/components/Sidebar/Sidebar.minors.tsx
@@ -6,6 +6,7 @@ import { ActiveStyles, ItemPropsIntrinsic } from './Sidebar.types';
 import { Button } from '../Button/Button';
 import { Tip } from '../Tip/Tip';
 import { core } from '../../tokens';
+import { grayscale, slate } from '../../color';
 
 export function Item({
   attach = 'right',
@@ -74,12 +75,33 @@ const ItemLabeledStyled = styled(Button)<{
   activeStyles?: ActiveStyles;
 }>`
   height: 4rem;
-  min-width: initial;
+  width: 4rem;
+  min-width: 4rem;
   padding: 0.25rem;
   margin: 2px 0;
   align-items: center;
   flex-direction: column;
-  ${({ isActive, activeStyles }) => (isActive ? activeStyles : '')};
+  overflow: hidden;
+  // The negative margin here is to adjust the look of the
+  // sidebar gutter, in order to avoid making an adjustment to the existing
+  // sidebar padding which would break the no-labels version of the sidebar
+  margin: 0.125rem -0.25rem;
+
+  ${({ isActive, activeStyles, theme }) =>
+    isActive && activeStyles
+      ? activeStyles
+      : isActive
+      ? {
+          backgroundColor: `${
+            theme.name == 'light' ? slate(100) : grayscale(600)
+          }`,
+        }
+      : {}};
+
+  &:hover {
+    background-color: ${({ theme }) =>
+      theme.name == 'light' ? slate(50) : grayscale(700)};
+  }
 
   > svg {
     // !important: Overrides padding placed on svg in Stylebar.style.ts
@@ -97,15 +119,15 @@ const ItemLabeledStyled = styled(Button)<{
   > span {
     font-weight: 400;
     text-overflow: initial;
-    overflow: visible;
     font-size: 0.6875rem;
     line-height: initial;
+    white-space: initial;
   }
 `;
 
 export const Break = styled.div`
-  width: calc(100% - 0.5rem);
-  border-top: 2px solid ${core.color.stroke};
-  margin: 1rem auto;
+  width: 100%;
+  border-top: 1px solid ${core.color.stroke};
+  margin: 0.75rem auto;
   transition: 120ms ease-in-out;
 `;

--- a/src/components/Sidebar/Sidebar.minors.tsx
+++ b/src/components/Sidebar/Sidebar.minors.tsx
@@ -33,7 +33,7 @@ export function Item({
       />
     </Tip>
   ) : (
-    <ItemLabeledStyled
+    <ItemLabelledStyled
       format="basic"
       icon={icon}
       onClick={onClick}
@@ -44,7 +44,7 @@ export function Item({
       {...props}
     >
       {label}
-    </ItemLabeledStyled>
+    </ItemLabelledStyled>
   );
 }
 
@@ -70,7 +70,7 @@ const ItemStyled = styled(Button)<{
   }
 `;
 
-const ItemLabeledStyled = styled(Button)<{
+const ItemLabelledStyled = styled(Button)<{
   isActive?: boolean;
   activeStyles?: ActiveStyles;
 }>`
@@ -95,9 +95,9 @@ const ItemLabeledStyled = styled(Button)<{
     // !important: Overrides padding placed on svg in Stylebar.style.ts
     padding: 0 !important;
     width: 1.25rem;
+    height: 1.25rem;
     min-width: 1.25rem;
     max-width: 1.25rem;
-    height: 1.25rem;
     min-height: 1.25rem;
     max-height: 1.25rem;
     margin: 0 0 0.45rem 0;

--- a/src/components/Sidebar/Sidebar.minors.tsx
+++ b/src/components/Sidebar/Sidebar.minors.tsx
@@ -12,12 +12,13 @@ export function Item({
   children = null,
   icon,
   label,
+  labelAsTooltip = true,
   onClick,
   isActive,
   activeStyles,
   ...props
 }: ItemPropsIntrinsic) {
-  return (
+  return labelAsTooltip ? (
     <Tip attach={attach} content={label}>
       <ItemStyled
         aria-label={label}
@@ -31,6 +32,19 @@ export function Item({
         {...props}
       />
     </Tip>
+  ) : (
+    <ItemLabeledStyled
+      format="basic"
+      icon={icon}
+      onClick={onClick}
+      size="md"
+      variant="minimalTransparent"
+      isActive={isActive}
+      activeStyles={activeStyles}
+      {...props}
+    >
+      {label}
+    </ItemLabeledStyled>
   );
 }
 
@@ -52,6 +66,40 @@ const ItemStyled = styled(Button)<{
     height: 1.25rem;
     min-height: 1.25rem;
     max-height: 1.25rem;
+  }
+`;
+
+const ItemLabeledStyled = styled(Button)<{
+  isActive?: boolean;
+  activeStyles?: ActiveStyles;
+}>`
+  height: 4rem;
+  min-width: initial;
+  padding: 0.25rem;
+  margin: 2px 0;
+  align-items: center;
+  flex-direction: column;
+  ${({ isActive, activeStyles }) => (isActive ? activeStyles : '')};
+
+  > svg {
+    // !important: Overrides padding placed on svg in Stylebar.style.ts
+    padding: 0 !important;
+    width: 1.25rem;
+    min-width: 1.25rem;
+    max-width: 1.25rem;
+    height: 1.25rem;
+    min-height: 1.25rem;
+    max-height: 1.25rem;
+    margin: 0 0 0.45rem 0;
+  }
+
+  // Button label
+  > span {
+    font-weight: 400;
+    text-overflow: initial;
+    overflow: visible;
+    font-size: 0.6875rem;
+    line-height: initial;
   }
 `;
 

--- a/src/components/Sidebar/Sidebar.minors.tsx
+++ b/src/components/Sidebar/Sidebar.minors.tsx
@@ -6,7 +6,6 @@ import { ActiveStyles, ItemPropsIntrinsic } from './Sidebar.types';
 import { Button } from '../Button/Button';
 import { Tip } from '../Tip/Tip';
 import { core } from '../../tokens';
-import { grayscale, slate } from '../../color';
 
 export function Item({
   attach = 'right',
@@ -57,7 +56,8 @@ const ItemStyled = styled(Button)<{
   text-align: left;
   padding: 0.25rem 0.25rem 0.25rem 0.75rem;
   justify-content: start;
-  ${({ isActive, activeStyles }) => (isActive ? activeStyles : '')};
+  ${({ isActive, activeStyles }) =>
+    isActive && activeStyles ? activeStyles : ''};
 
   > svg {
     padding: 0 !important;
@@ -76,6 +76,7 @@ const ItemLabeledStyled = styled(Button)<{
 }>`
   height: 4rem;
   width: 4rem;
+  min-height: 4rem;
   min-width: 4rem;
   padding: 0.25rem;
   margin: 2px 0;
@@ -87,21 +88,8 @@ const ItemLabeledStyled = styled(Button)<{
   // sidebar padding which would break the no-labels version of the sidebar
   margin: 0.125rem -0.25rem;
 
-  ${({ isActive, activeStyles, theme }) =>
-    isActive && activeStyles
-      ? activeStyles
-      : isActive
-      ? {
-          backgroundColor: `${
-            theme.name == 'light' ? slate(100) : grayscale(600)
-          }`,
-        }
-      : {}};
-
-  &:hover {
-    background-color: ${({ theme }) =>
-      theme.name == 'light' ? slate(50) : grayscale(700)};
-  }
+  ${({ isActive, activeStyles }) =>
+    isActive && activeStyles ? activeStyles : ''}
 
   > svg {
     // !important: Overrides padding placed on svg in Stylebar.style.ts

--- a/src/components/Sidebar/Sidebar.minors.tsx
+++ b/src/components/Sidebar/Sidebar.minors.tsx
@@ -128,6 +128,6 @@ const ItemLabeledStyled = styled(Button)<{
 export const Break = styled.div`
   width: 100%;
   border-top: 1px solid ${core.color.stroke};
-  margin: 0.75rem auto;
+  margin: 0.35rem auto;
   transition: 120ms ease-in-out;
 `;

--- a/src/components/Sidebar/Sidebar.story.tsx
+++ b/src/components/Sidebar/Sidebar.story.tsx
@@ -3,9 +3,15 @@ import styled from 'styled-components';
 import { Story } from '@storybook/react';
 
 import { Sidebar } from './Sidebar';
-import { Props } from './Sidebar.types';
+import { Props, ItemPropsIntrinsic } from './Sidebar.types';
 
-import { Gear } from '../../icons';
+import {
+  Gear,
+  Lock,
+  Interactive,
+  SpeechBubbleSquared,
+  LineChartOutlined,
+} from '../../icons';
 import { Header as H } from '../../typography';
 import { Layout } from '../../storybook';
 
@@ -14,6 +20,7 @@ export default {
   component: Sidebar,
   argTypes: {
     state: { control: { disable: true } },
+    labelAsTooltip: { control: 'boolean', defaultValue: true },
   },
 };
 
@@ -21,37 +28,66 @@ const Header = styled(H)`
   margin-top: 0;
 `;
 
-const Template: Story<Props> = ({ attach = 'left', ...args }) => {
+const Template: Story<
+  Props & Pick<ItemPropsIntrinsic, 'labelAsTooltip'>
+> = ({ attach = 'left', labelAsTooltip, ...args }) => {
   const style =
     attach === 'right'
       ? ({ position: 'absolute', top: 0, right: 0 } as const)
       : null;
-
   return (
     <Layout.FullBleed>
-      <Sidebar attach={attach} {...args} style={style}>
-        <Sidebar.Item label="Item 1" icon={<Gear />}>
-          <Header size="3">Item 1</Header>
+      <Sidebar
+        attach={attach}
+        {...args}
+        style={style}
+        activeStyles={{
+          background: 'rgba(0,0,0,0.1)',
+          color: '#262626',
+        }}
+      >
+        <Sidebar.Item
+          label="Privacy"
+          labelAsTooltip={labelAsTooltip}
+          icon={<Lock />}
+        >
+          <Header size="3">Privacy</Header>
         </Sidebar.Item>
 
-        <Sidebar.Item label="Item 2" icon={<Gear />}>
-          <Header size="3">Item 2</Header>
+        <Sidebar.Item
+          label="Interactive"
+          labelAsTooltip={labelAsTooltip}
+          icon={<Interactive />}
+        >
+          <Header size="3">Interactive</Header>
         </Sidebar.Item>
 
         <Sidebar.Break />
 
-        <Sidebar.Item label="Item 3" icon={<Gear />}>
-          <Header size="3">Item 3</Header>
+        <Sidebar.Item
+          label="Comments"
+          labelAsTooltip={labelAsTooltip}
+          icon={<SpeechBubbleSquared />}
+        >
+          <Header size="3">Comments</Header>
         </Sidebar.Item>
 
-        <Sidebar.Item label="Item 4" icon={<Gear />}>
-          <Header size="3">Item 1</Header>
+        <Sidebar.Item
+          label="Analytics"
+          labelAsTooltip={labelAsTooltip}
+          icon={<LineChartOutlined />}
+        >
+          <Header size="3">Analytics</Header>
         </Sidebar.Item>
 
         <Sidebar.Break />
 
-        <Sidebar.Item label="Item 5" icon={<Gear />}>
-          <Header size="3">Item 4</Header>
+        <Sidebar.Item
+          label="Settings"
+          labelAsTooltip={labelAsTooltip}
+          icon={<Gear />}
+        >
+          <Header size="3">Settings</Header>
         </Sidebar.Item>
       </Sidebar>
     </Layout.FullBleed>

--- a/src/components/Sidebar/Sidebar.story.tsx
+++ b/src/components/Sidebar/Sidebar.story.tsx
@@ -11,6 +11,7 @@ import {
   Interactive,
   SpeechBubbleSquared,
   LineChartOutlined,
+  Eye,
 } from '../../icons';
 import { Header as H } from '../../typography';
 import { Layout } from '../../storybook';
@@ -37,15 +38,7 @@ const Template: Story<
       : null;
   return (
     <Layout.FullBleed>
-      <Sidebar
-        attach={attach}
-        {...args}
-        style={style}
-        activeStyles={{
-          background: 'rgba(0,0,0,0.1)',
-          color: '#262626',
-        }}
-      >
+      <Sidebar attach={attach} {...args} style={style}>
         <Sidebar.Item
           label="Privacy"
           labelAsTooltip={labelAsTooltip}
@@ -89,6 +82,18 @@ const Template: Story<
         >
           <Header size="3">Settings</Header>
         </Sidebar.Item>
+
+        {!labelAsTooltip ? (
+          <Sidebar.Item
+            label="Longer Label"
+            labelAsTooltip={false}
+            icon={<Eye />}
+          >
+            <Header size="3">Long Label</Header>
+          </Sidebar.Item>
+        ) : (
+          <></>
+        )}
       </Sidebar>
     </Layout.FullBleed>
   );

--- a/src/components/Sidebar/Sidebar.style.ts
+++ b/src/components/Sidebar/Sidebar.style.ts
@@ -10,7 +10,7 @@ export const SidebarStyled = styled.div<{
 }>`
   position: relative;
   z-index: 1500;
-  width: 4.5rem;
+  min-width: 4.5rem;
   height: 100%;
   padding: 0.75rem;
   transition: all 90ms ease-in-out, width 150ms ease-in-out,
@@ -40,6 +40,7 @@ export const SidebarStyled = styled.div<{
 `;
 
 export const PanelStyled = styled.div<{
+  offset: number;
   attach: Props['attach'];
   visible: boolean;
 }>`
@@ -60,8 +61,8 @@ export const PanelStyled = styled.div<{
   ${attach};
 `;
 
-function left({ attach }) {
-  return attach === 'left' ? '4.5rem' : '1px';
+function left({ attach, offset }) {
+  return attach === 'left' ? offset + 'px' : '1px';
 }
 
 function attach({ attach }) {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -23,10 +23,6 @@ export const Sidebar = withIris<HTMLDivElement, Props, Minors>(
 Sidebar.Item = Item;
 Sidebar.Break = Break;
 
-// const defaultActiveStyles = css`
-//   background-color: ${(theme) => theme.content.background},
-// `
-
 function SidebarComponent({
   children,
   attach = 'left',

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -23,6 +23,10 @@ export const Sidebar = withIris<HTMLDivElement, Props, Minors>(
 Sidebar.Item = Item;
 Sidebar.Break = Break;
 
+// const defaultActiveStyles = css`
+//   background-color: ${(theme) => theme.content.background},
+// `
+
 function SidebarComponent({
   children,
   attach = 'left',
@@ -76,7 +80,7 @@ function SidebarComponent({
       attach: attach === 'left' ? 'right' : 'left',
       onClick: toggle(child),
       key,
-      isActive: activeStyles && active === child.props.label,
+      isActive: active === child.props.label,
       activeStyles,
     });
   }

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,9 @@
-import React, { cloneElement } from 'react';
+import React, {
+  cloneElement,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { Item, Break } from './Sidebar.minors';
 import { SidebarStyled, PanelStyled, Dismiss } from './Sidebar.style';
@@ -31,6 +36,12 @@ function SidebarComponent({
 }: Props) {
   const [active, activeSet] = useStateTransmorphic<string>(state);
   const [layoutStyles, displayStyles] = useLayoutStyles(style);
+  const sidebarRef = useRef<HTMLDivElement | null>(null);
+  const [sidebarWidth, setSidebarWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    setSidebarWidth(sidebarRef?.current?.clientWidth ?? 0);
+  }, [sidebarRef?.current?.clientWidth]);
 
   // Extract the active Sidebar.Item's children.
   const panel = children.filter(
@@ -74,10 +85,19 @@ function SidebarComponent({
 
   return (
     <div style={{ height: '100%', ...layoutStyles }} ref={forwardRef}>
-      <SidebarStyled attach={attach} style={displayStyles} {...props}>
+      <SidebarStyled
+        ref={sidebarRef}
+        attach={attach}
+        style={displayStyles}
+        {...props}
+      >
         {children}
       </SidebarStyled>
-      <PanelStyled attach={attach} visible={panel}>
+      <PanelStyled
+        attach={attach}
+        visible={panel}
+        offset={sidebarWidth}
+      >
         <Dismiss
           aria-label="Dismiss"
           format="basic"

--- a/src/components/Sidebar/Sidebar.types.ts
+++ b/src/components/Sidebar/Sidebar.types.ts
@@ -26,6 +26,7 @@ export interface ItemPropsExtrinsic {
   children?: ReactElement;
   icon?: ReactElement;
   label: string;
+  labelAsTooltip?: boolean;
   onClick?: MouseEventHandler;
 }
 


### PR DESCRIPTION
## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Modify the Sidebar component to support labels.

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->
<img width="99" alt="Screenshot 2023-05-30 at 1 29 16 PM" src="https://github.com/vimeo/iris/assets/2123735/33a18544-d71d-477e-88c3-f4fd8a50a195">

**New control added to show/hide labels**
![Screenshot 2023-05-23 at 11 22 03 AM](https://github.com/vimeo/iris/assets/2123735/4e6f9f7b-fe90-430e-9286-26e442d951ed)

## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->
Adds a `labelAsTooltip` property to inform the sidebar items whether or not to use the provided label as a tooltip or as label text. Modifies some widths here and there to support larger items now that text is included

## Testing <!-- instructions on how to test -->
Check it out in storybook
https://vimeo.github.io/iris/sb/WRKFL-2650/?path=/story/components-sidebar--controls&args=labelAsTooltip:false
