### PR TITLE
moved logic to slider (not on handle)

### DIFF
--- a/src/components/inputs/Slider/Handle.tsx
+++ b/src/components/inputs/Slider/Handle.tsx
@@ -41,9 +41,6 @@ export function Handle({
       onMouseDown={() => {
         !disabled && setDragging(handle);
       }}
-      onMouseUp={(event) =>
-        !disabled && onDragEnd && onDragEnd(event)
-      }
       {...props}
     >
       <Hidden

--- a/src/components/inputs/Slider/Slider.tsx
+++ b/src/components/inputs/Slider/Slider.tsx
@@ -71,7 +71,10 @@ export function Slider({
   }, [dragging]);
 
   useEffect(() => {
-    const mouseup = () => dragging && setDragging(false);
+    const mouseup = (event) => {
+      dragging && setDragging(false);
+      onDragEnd && onDragEnd(event);
+    };
 
     document && document.addEventListener('mouseup', mouseup);
     return () =>


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
moved onDragEnd to onmuseup of slider (instead of keeping it in handle) to solve the problem when dragEnd is happening outside of the handle range (happens for example on popovers when you drag to 0 or 100 and release outside of the popover)

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->

[New Recording - 5_29_2023, 4_38_42 PM.webm](https://github.com/vimeo/iris/assets/38322603/4eaf4e0d-7bae-4ab6-81f2-8fbf1d83964f)


