### PR TITLE
Remove pnpm version from engines property

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,8 +134,7 @@
         "url": "https://github.com/vimeo/iris.git"
     },
     "engines": {
-        "node": ">=12.0.0",
-        "pnpm": "7.26.3"
+        "node": ">=12.0.0"
     },
     "prettier": {
         "parser": "typescript",


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->

Removes the `pnpm` property from the required `engines` as it would require consuming packages to also use this version, which is needlessly strict.

