### PR TITLE
Redesign Slider and add a11y support

### DIFF
--- a/src/components/inputs/Slider/Handle.tsx
+++ b/src/components/inputs/Slider/Handle.tsx
@@ -1,79 +1,24 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 
-import {
-  HandleStyled,
-  Hidden,
-  LabelInput,
-  Label,
-} from './Slider.style';
-
-import { Focus } from '../../../utils';
+import { HandleStyled } from './Slider.style';
 
 export function Handle({
   disabled,
   dragging,
-  editableLabel,
-  focused,
-  formatter,
   handle,
   max,
-  min,
-  onChange,
-  onDragEnd,
   setDragging,
-  setFocus,
-  setValue,
   value,
   ...props
 }) {
-  const ref = useRef(null);
-
-  useEffect(() => {
-    const event = new Event('change', { bubbles: true });
-    ref?.current?.dispatchEvent(event);
-    onChange && onChange(event);
-  }, [onChange, value]);
-
   return (
     <HandleStyled
-      focused={focused === handle || dragging === handle}
       style={{ left: (value / max) * 100 + '%' }}
+      aria-label={handle}
       onMouseDown={() => {
         !disabled && setDragging(handle);
       }}
       {...props}
-    >
-      <Hidden
-        min={min}
-        max={max}
-        value={value}
-        onFocus={setFocus(handle)}
-        onBlur={setFocus(false)}
-        ref={ref}
-        readOnly
-      />
-      <Focus
-        parent={Hidden}
-        radius={50}
-        focused={focused === handle || dragging === handle}
-      />
-
-      <Label focused={focused}>
-        {editableLabel ? (
-          <>
-            <LabelInput
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              onFocus={setFocus(handle)}
-              onBlur={setFocus(false)}
-              focused={focused === handle}
-            />
-            <Focus parent={LabelInput} distance={1} />
-          </>
-        ) : (
-          formatter(value)
-        )}
-      </Label>
-    </HandleStyled>
+    />
   );
 }

--- a/src/components/inputs/Slider/Handle.tsx
+++ b/src/components/inputs/Slider/Handle.tsx
@@ -1,24 +1,46 @@
 import React from 'react';
 
-import { HandleStyled } from './Slider.style';
+import { HandleStyled, Hidden } from './Slider.style';
+import { Focus } from '../../../utils';
 
-export function Handle({
-  disabled,
-  dragging,
-  handle,
-  max,
-  setDragging,
-  value,
-  ...props
-}) {
-  return (
-    <HandleStyled
-      style={{ left: (value / max) * 100 + '%' }}
-      aria-label={handle}
-      onMouseDown={() => {
-        !disabled && setDragging(handle);
-      }}
-      {...props}
-    />
-  );
+interface Props {
+  disabled: boolean;
+  handle: string;
+  min: number;
+  max: number;
+  setDragging: (value: string) => void;
+  setFocus: (value: string) => void;
+  value: number;
 }
+
+export const Handle = React.forwardRef<HTMLInputElement, Props>(
+  (
+    { disabled, handle, min, max, setDragging, setFocus, value },
+    ref
+  ) => {
+    return (
+      <HandleStyled
+        style={{ left: (value / max) * 100 + '%' }}
+        aria-label={handle}
+        onMouseDown={() => {
+          !disabled && setDragging(handle);
+        }}
+      >
+        <Hidden
+          min={min}
+          max={max}
+          value={value}
+          onFocus={() => {
+            setFocus(handle);
+          }}
+          onBlur={() => {
+            setFocus(null);
+          }}
+          ref={ref}
+          readOnly
+        />
+        <Focus parent={Hidden} radius={50} isKeyboardOnly />
+      </HandleStyled>
+    );
+  }
+);

--- a/src/components/inputs/Slider/Slider.style.ts
+++ b/src/components/inputs/Slider/Slider.style.ts
@@ -3,10 +3,12 @@ import styled from 'styled-components';
 import { blue, white } from '../../../color';
 import { rgba } from 'polished';
 
-export const SliderContainer = styled.div`
+export const SliderContainer = styled.div<{ range: boolean }>`
   display: flex;
   align-items: center;
   gap: 16px;
+  margin: 0.75rem 0;
+  margin-left: ${({ range }) => (range ? 0 : '0.75rem')};
 `;
 
 export const Label = styled.div<{ focused: boolean }>`

--- a/src/components/inputs/Slider/Slider.style.ts
+++ b/src/components/inputs/Slider/Slider.style.ts
@@ -1,36 +1,33 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
-import { white } from '../../../color';
+import { blue, white } from '../../../color';
 import { rgba } from 'polished';
 
+export const SliderContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`;
+
 export const Label = styled.div<{ focused: boolean }>`
-  position: absolute;
-  top: 100%;
-  transform: translate(-30%, 0.5rem);
-  padding: 0.5rem;
-  width: 3rem;
+  padding: 0.2125rem;
+  width: 3.125rem;
   text-align: center;
   border-radius: 0.25rem;
-  border: 1px solid ${({ theme }) => rgba(theme.content.color, 0.334)};
-  transition: 100ms ease-in-out;
+  border: 1px solid
+    ${({ theme, focused }) =>
+      focused ? blue(500) : rgba(theme.content.color, 0.334)};
   background: ${({ theme }) => theme.item.bg};
   color: ${({ theme }) => theme.content.color};
-
-  ${(p) =>
-    p.focused &&
-    css`
-      transform: translate(-25%, 0.75rem) scale(1.075);
-    `}
+  font-size: 0.75rem;
 `;
 
 export const LabelInput = styled.input.attrs({ type: 'number' })<{
   value: number;
   onChange: any;
   onFocus: any;
-  focused: boolean;
 }>`
   width: 100%;
-  font-size: 1rem;
   padding: 0;
   margin: 0;
   background: ${({ theme }) => theme.item.bg};
@@ -40,6 +37,7 @@ export const LabelInput = styled.input.attrs({ type: 'number' })<{
   overflow: visible;
   appearance: none;
   text-align: center;
+  font-size: inherit;
 
   &::-webkit-inner-spin-button {
     appearance: none;
@@ -55,8 +53,8 @@ export const HandleStyled = styled.div<{ focused?: boolean }>`
   border-radius: 50%;
   background: ${white};
   position: absolute;
-  top: -0.5rem;
-  transform: translateX(-50%);
+  top: 0;
+  transform: translate(-50%, -45%);
   cursor: pointer;
   border: 1px solid ${({ theme }) => rgba(theme.content.color, 0.1)};
   z-index: 2;
@@ -75,12 +73,22 @@ export const Background = styled.div`
 export const ActiveRange = styled.div.attrs<{
   values?: number[];
   max?: number;
-}>(({ values, max }) => ({
-  style: {
-    width: ((values[1] - values[0]) / max) * 100 + '%',
-    left: (values[0] / max) * 100 + '%',
-  },
-}))<{ values?: number[]; max?: number }>`
+  range?: boolean;
+}>(({ values, max, range }) =>
+  range
+    ? {
+        style: {
+          width: ((values[1] - values[0]) / max) * 100 + '%',
+          left: (values[0] / max) * 100 + '%',
+        },
+      }
+    : {
+        style: {
+          left: 0,
+          width: (values[0] / max) * 100 + '%',
+        },
+      }
+)<{ values?: number[]; max?: number; range?: boolean }>`
   pointer-events: none;
   position: absolute;
   height: 100%;

--- a/src/components/inputs/Slider/Slider.test.tsx
+++ b/src/components/inputs/Slider/Slider.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ThemeProvider } from 'styled-components';
+import { themes } from '../../../themes';
+import { Slider } from './Slider';
+
+describe('Slider', () => {
+  it('Renders slider', () => {
+    render(
+      <ThemeProvider theme={themes['light']}>
+        <Slider />
+      </ThemeProvider>
+    );
+
+    const slider = screen.getByLabelText('slider');
+    expect(slider).toBeInTheDocument();
+  });
+
+  it('Renders slider with 50% value', async () => {
+    render(
+      <ThemeProvider theme={themes['light']}>
+        <Slider initialValues={[0, 100]} editableLabel />
+      </ThemeProvider>
+    );
+
+    const input = screen.getByRole('start-input');
+    await userEvent.click(input);
+    fireEvent.change(input, { target: { value: 50 } });
+
+    const handle = screen.getByLabelText('startHandle');
+    expect(handle).toHaveStyle({ left: '50%' });
+  });
+
+  it('Renders slider with min and max', async () => {
+    render(
+      <ThemeProvider theme={themes['light']}>
+        <Slider
+          initialValues={[0, 100]}
+          editableLabel
+          min={0}
+          max={100}
+          range
+        />
+      </ThemeProvider>
+    );
+
+    const endInput = screen.getByRole('end-input');
+    await userEvent.click(endInput);
+    fireEvent.change(endInput, { target: { value: 120 } });
+
+    const endHandle = screen.getByLabelText('endHandle');
+    expect(endHandle).toHaveStyle({ left: '100%' });
+
+    const startInput = screen.getByRole('start-input');
+    await userEvent.click(startInput);
+    fireEvent.change(startInput, { target: { value: -10 } });
+
+    const startHandle = screen.getByLabelText('startHandle');
+    expect(startHandle).toHaveStyle({ left: '0%' });
+  });
+
+  it('Renders slider and fire onChange', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <ThemeProvider theme={themes['light']}>
+        <Slider
+          onChange={onChange}
+          initialValues={[0, 100]}
+          editableLabel
+        />
+      </ThemeProvider>
+    );
+
+    const input = screen.getByRole('start-input');
+    await userEvent.click(input);
+    fireEvent.change(input, { target: { value: 50 } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cannot change value of disabled slider', async () => {
+    render(
+      <ThemeProvider theme={themes['light']}>
+        <Slider initialValues={[0, 100]} disabled editableLabel />
+      </ThemeProvider>
+    );
+
+    const input = screen.getByRole('start-input');
+    expect(input).toHaveAttribute('disabled');
+  });
+});

--- a/src/components/inputs/Slider/Slider.test.tsx
+++ b/src/components/inputs/Slider/Slider.test.tsx
@@ -92,4 +92,31 @@ describe('Slider', () => {
     const input = screen.getByRole('start-input');
     expect(input).toHaveAttribute('disabled');
   });
+
+  it('Limit values based on range', async () => {
+    render(
+      <ThemeProvider theme={themes['light']}>
+        <Slider initialValues={[0, 100]} range editableLabel />
+      </ThemeProvider>
+    );
+
+    const endInput = screen.getByRole('end-input');
+    await userEvent.click(endInput);
+    fireEvent.change(endInput, { target: { value: 80 } });
+
+    const startInput = screen.getByRole('start-input');
+    await userEvent.click(startInput);
+    fireEvent.change(startInput, { target: { value: 90 } });
+
+    const startHandle = screen.getByLabelText('startHandle');
+    expect(startHandle).toHaveStyle({ left: '79%' });
+
+    const endHandle = screen.getByLabelText('endHandle');
+    expect(endHandle).toHaveStyle({ left: '80%' });
+
+    await userEvent.click(endInput);
+    fireEvent.change(endInput, { target: { value: 20 } });
+
+    expect(endHandle).toHaveStyle({ left: '80%' });
+  });
 });

--- a/src/components/inputs/Slider/Slider.tsx
+++ b/src/components/inputs/Slider/Slider.tsx
@@ -19,8 +19,7 @@ import {
 } from './Slider.style';
 import { Handle } from './Handle';
 
-import { white } from '../../../color';
-import { Focus, geometry, useOutsideClick } from '../../../utils';
+import { geometry, useOutsideClick } from '../../../utils';
 import {
   arrowDown,
   arrowLeft,
@@ -169,7 +168,7 @@ export function Slider({
   return (
     <SliderContainer
       {...props}
-      style={{ color: white, margin: '0.75rem 0' }}
+      range={range}
       aria-label="slider"
       role="slider"
       aria-valuemin={min}
@@ -181,18 +180,15 @@ export function Slider({
       {range && (
         <Label focused={focused === 'startInput'}>
           {editableLabel ? (
-            <>
-              <LabelInput
-                value={values[0]}
-                disabled={disabled}
-                onFocus={() => setFocus('startInput')}
-                onChange={(e) =>
-                  !e.button && setStartValue(parseInt(e.target.value))
-                }
-                role="start-input"
-              />
-              <Focus parent={LabelInput} distance={1} />
-            </>
+            <LabelInput
+              value={values[0]}
+              disabled={disabled}
+              onFocus={() => setFocus('startInput')}
+              onChange={(e) =>
+                !e.button && setStartValue(parseInt(e.target.value))
+              }
+              role="start-input"
+            />
           ) : (
             formatter(values[0])
           )}
@@ -234,22 +230,19 @@ export function Slider({
         focused={focused === (range ? 'endInput' : 'startInput')}
       >
         {editableLabel ? (
-          <>
-            <LabelInput
-              value={range ? values[1] : values[0]}
-              disabled={disabled}
-              onFocus={() =>
-                setFocus(range ? 'endInput' : 'startInput')
-              }
-              onChange={(e) => {
-                range
-                  ? setEndValue(parseInt(e.target.value))
-                  : setStartValue(parseInt(e.target.value));
-              }}
-              role={range ? 'end-input' : 'start-input'}
-            />
-            <Focus parent={LabelInput} distance={1} />
-          </>
+          <LabelInput
+            value={range ? values[1] : values[0]}
+            disabled={disabled}
+            onFocus={() =>
+              setFocus(range ? 'endInput' : 'startInput')
+            }
+            onChange={(e) => {
+              range
+                ? setEndValue(parseInt(e.target.value))
+                : setStartValue(parseInt(e.target.value));
+            }}
+            role={range ? 'end-input' : 'start-input'}
+          />
         ) : (
           formatter(range ? values[1] : values[0])
         )}

--- a/src/components/inputs/Slider/Slider.tsx
+++ b/src/components/inputs/Slider/Slider.tsx
@@ -16,7 +16,6 @@ import {
   Label,
   LabelInput,
   SliderContainer,
-  Hidden,
 } from './Slider.style';
 import { Handle } from './Handle';
 
@@ -58,7 +57,6 @@ export function Slider({
   const trackRef = useRef(null);
   const startHandleRef = useRef(null);
   const endHandleRef = useRef(null);
-  const hiddenInputRef = useRef(null);
 
   useOutsideClick([trackRef], () => {
     setFocus(null);
@@ -72,8 +70,11 @@ export function Slider({
   const { values, trackRect, focused, dragging }: State = state;
 
   function dispatchChangeEvent(callback) {
+    const currentInput =
+      focused === 'startHandle' ? startHandleRef : endHandleRef;
+
     const event = new Event('change', { bubbles: true });
-    hiddenInputRef?.current?.dispatchEvent(event);
+    currentInput?.current?.dispatchEvent(event);
     callback && callback(event);
   }
 
@@ -178,10 +179,7 @@ export function Slider({
       }
     >
       {range && (
-        <Label
-          ref={startHandleRef}
-          focused={focused === 'startInput'}
-        >
+        <Label focused={focused === 'startInput'}>
           {editableLabel ? (
             <>
               <LabelInput
@@ -210,28 +208,29 @@ export function Slider({
       >
         <Handle
           disabled={disabled}
-          dragging={dragging}
           handle="startHandle"
+          min={min}
           max={max}
-          onChange={onChange}
+          setFocus={setFocus}
           setDragging={setDragging}
           value={values[0]}
+          ref={startHandleRef}
         />
 
         {range && (
           <Handle
             disabled={disabled}
-            dragging={dragging}
             handle="endHandle"
+            min={min}
             max={max}
-            onChange={onChange}
+            setFocus={setFocus}
             setDragging={setDragging}
             value={values[1]}
+            ref={endHandleRef}
           />
         )}
       </Track>
       <Label
-        ref={range ? endHandleRef : startHandleRef}
         focused={focused === (range ? 'endInput' : 'startInput')}
       >
         {editableLabel ? (
@@ -255,13 +254,6 @@ export function Slider({
           formatter(range ? values[1] : values[0])
         )}
       </Label>
-      <Hidden
-        min={min}
-        max={max}
-        value={dragging === 'startHandle' ? values[0] : values[1]}
-        ref={hiddenInputRef}
-        readOnly
-      />
     </SliderContainer>
   );
 }
@@ -290,7 +282,7 @@ const Track = forwardRef(
   }
 );
 
-function isHandleFocused(focusedElement: string) {
+function isHandleFocused(focusedElement: State['focused']) {
   return focusedElement.includes('Handle');
 }
 

--- a/src/components/inputs/Slider/Slider.tsx
+++ b/src/components/inputs/Slider/Slider.tsx
@@ -10,16 +10,23 @@ import React, {
 
 import { Props } from './Slider.types';
 import { initialState, reducer } from './Slider.state';
-import { Background, ActiveRange } from './Slider.style';
+import {
+  Background,
+  ActiveRange,
+  Label,
+  LabelInput,
+  SliderContainer,
+  Hidden,
+} from './Slider.style';
 import { Handle } from './Handle';
 
 import { white } from '../../../color';
-import { geometry } from '../../../utils';
+import { Focus, geometry } from '../../../utils';
 
 interface State {
   values: number[];
   trackRect: any;
-  focused: boolean;
+  focused: string;
   dragging: 'startHandle' | 'endHandle';
 }
 
@@ -35,12 +42,20 @@ export function Slider({
   range,
   ...props
 }: Props) {
-  const ref = useRef(null);
+  const trackRef = useRef(null);
+  const hiddenInputRef = useRef(null);
+
   const [state, dispatch] = useReducer(
     reducer,
     initialState(initialValues)
   );
   const { values, trackRect, focused, dragging }: State = state;
+
+  function dispatchChangeEvent(callback) {
+    const event = new Event('change', { bubbles: true });
+    hiddenInputRef?.current?.dispatchEvent(event);
+    callback && callback(event);
+  }
 
   function setDragging(payload) {
     setFocus(payload);
@@ -48,6 +63,7 @@ export function Slider({
   }
 
   function setValue(payload) {
+    dispatchChangeEvent(onChange);
     return dispatch({ type: 'SET_VALUES', payload });
   }
 
@@ -66,14 +82,14 @@ export function Slider({
   }
 
   useLayoutEffect(() => {
-    const { left, width } = geometry(ref.current);
+    const { left, width } = geometry(trackRef.current);
     dispatch({ type: 'SET_TRACK_RECT', payload: { left, width } });
   }, [dragging]);
 
   useEffect(() => {
-    const mouseup = (event) => {
+    const mouseup = () => {
+      dispatchChangeEvent(onDragEnd);
       dragging && setDragging(false);
-      onDragEnd && onDragEnd(event);
     };
 
     document && document.addEventListener('mouseup', mouseup);
@@ -97,22 +113,51 @@ export function Slider({
   });
 
   return (
-    <div {...props} style={{ color: white, margin: '4rem 0' }}>
-      <Track ref={ref} values={values} id="track-1" max={max}>
+    <SliderContainer
+      {...props}
+      style={{ color: white, margin: '0.75rem 0' }}
+      aria-label="slider"
+      role="slider"
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={
+        dragging === 'startHandle' ? values[0] : values[1]
+      }
+    >
+      {range && (
+        <Label focused={focused === 'startHandle'}>
+          {editableLabel ? (
+            <>
+              <LabelInput
+                value={values[0]}
+                disabled={disabled}
+                onChange={(e) => setStartValue(e.target.value)}
+                onFocus={setFocus('startHandle')}
+                onBlur={setFocus(false)}
+                role="start-input"
+              />
+              <Focus parent={LabelInput} distance={1} />
+            </>
+          ) : (
+            formatter(values[0])
+          )}
+        </Label>
+      )}
+      <Track
+        ref={trackRef}
+        values={values}
+        id="track-1"
+        max={max}
+        range={range}
+        aria-label="track"
+      >
         <Handle
           disabled={disabled}
           dragging={dragging}
-          editableLabel={editableLabel}
-          focused={focused}
-          formatter={formatter}
           handle="startHandle"
           max={max}
-          min={min}
           onChange={onChange}
-          onDragEnd={onDragEnd}
           setDragging={setDragging}
-          setFocus={setFocus}
-          setValue={setStartValue}
           value={values[0]}
         />
 
@@ -120,22 +165,45 @@ export function Slider({
           <Handle
             disabled={disabled}
             dragging={dragging}
-            editableLabel={editableLabel}
-            focused={focused}
-            formatter={formatter}
             handle="endHandle"
             max={max}
-            min={min}
             onChange={onChange}
-            onDragEnd={onDragEnd}
             setDragging={setDragging}
-            setFocus={setFocus}
-            setValue={setEndValue}
             value={values[1]}
           />
         )}
       </Track>
-    </div>
+      <Label
+        focused={focused === (range ? 'endHandle' : 'startHandle')}
+      >
+        {editableLabel ? (
+          <>
+            <LabelInput
+              value={range ? values[1] : values[0]}
+              disabled={disabled}
+              onChange={(e) => {
+                range
+                  ? setEndValue(e.target.value)
+                  : setStartValue(e.target.value);
+              }}
+              onFocus={setFocus(range ? 'endHandle' : 'startHandle')}
+              onBlur={setFocus(false)}
+              role={range ? 'end-input' : 'start-input'}
+            />
+            <Focus parent={LabelInput} distance={1} />
+          </>
+        ) : (
+          formatter(range ? values[1] : values[0])
+        )}
+      </Label>
+      <Hidden
+        min={min}
+        max={max}
+        value={dragging === 'startHandle' ? values[0] : values[1]}
+        ref={hiddenInputRef}
+        readOnly
+      />
+    </SliderContainer>
   );
 }
 
@@ -145,14 +213,19 @@ interface TrackProps {
   ref: Ref<HTMLDivElement>;
   values: number[];
   max: number;
+  range: boolean;
 }
 
 const Track = forwardRef(
-  ({ children, values, max, ...props }: TrackProps, ref) => {
+  ({ children, values, max, range, ...props }: TrackProps, ref) => {
     return (
       <Background ref={ref} {...props}>
         {children}
-        <ActiveRange values={values} max={max}></ActiveRange>
+        <ActiveRange
+          values={values}
+          max={max}
+          range={range}
+        ></ActiveRange>
       </Background>
     );
   }

--- a/src/utils/events/KeyCodes.ts
+++ b/src/utils/events/KeyCodes.ts
@@ -1,5 +1,9 @@
 export const arrowRight = 39;
 export const arrowLeft = 37;
+export const arrowUp = 38;
+export const arrowDown = 40;
+export const home = 36;
+export const end = 35;
 export const enter = 13;
 export const esc = 27;
 export const spacebar = 32;


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

Initial comments in this PR - https://github.com/vimeo/iris/pull/280

https://vimean.atlassian.net/browse/DSYS-4
https://vimean.atlassian.net/browse/DSYS-5
**Storybook:** https://vimeo.github.io/iris/sb/DSYS-4-DSYS-5-slider-updates/?path=/story/components-slider--controls

## What this PR does 
* Change the design on Slider component based on the new approved design.
* Added values in onDragEnd callback
* Added support for a11y - arrow keys and home/end keys support.
* Fixed a bug where min / max can overlap each other.
* Added unit tests

## Screenshots & Recordings 
https://github.com/vimeo/iris/assets/9106375/1bddfc1b-5832-4f30-8061-d5c8857df185


## How it does that 
* Move input out from the `Handle` component into the main `Slider` component.
* Remove unused styling.
* Added 2 more focus types for inputs so it won't collide with keydown events.
* Better manage focus so it can react to key events.

## Testing 
![image](https://github.com/vimeo/iris/assets/9106375/d9790d86-4a46-43b8-b4e9-879d22a859e8)

