### PR TITLE
Optimize event firing and use correct (not stale) value

### DIFF
--- a/src/components/inputs/Slider/Slider.test.tsx
+++ b/src/components/inputs/Slider/Slider.test.tsx
@@ -126,4 +126,18 @@ describe('Slider', () => {
 
     expect(endHandle).toHaveStyle({ left: '80%' });
   });
+
+  it('Does not fire event on inital render', async () => {
+    const onChange = jest.fn();
+    const onDragEnd = jest.fn();
+
+    render(
+      <ThemeProvider theme={themes['light']}>
+        <Slider initialValues={[0, 100]} editableLabel />
+      </ThemeProvider>
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(0);
+    expect(onDragEnd).toHaveBeenCalledTimes(0);
+  });
 });

--- a/src/components/inputs/Slider/Slider.tsx
+++ b/src/components/inputs/Slider/Slider.tsx
@@ -126,19 +126,13 @@ export function Slider({
   }, [onChange, values]);
 
   useEffect(() => {
-    if (!isFirstRender.current && !dragging) {
-      dispatchChangeEvent(onDragEnd);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onDragEnd, dragging]);
-
-  useEffect(() => {
     isFirstRender.current = false;
   }, []);
 
   useEffect(() => {
     const mouseup = () => {
       dragging && setDragging(false);
+      dispatchChangeEvent(onDragEnd);
     };
 
     const keydown = (event) => {

--- a/src/components/inputs/Slider/Slider.tsx
+++ b/src/components/inputs/Slider/Slider.tsx
@@ -6,6 +6,7 @@ import React, {
   ReactNode,
   forwardRef,
   Ref,
+  useCallback,
 } from 'react';
 
 import { Props } from './Slider.types';
@@ -53,6 +54,7 @@ export function Slider({
   range,
   ...props
 }: Props) {
+  const isFirstRender = useRef(true);
   const trackRef = useRef(null);
   const startHandleRef = useRef(null);
   const endHandleRef = useRef(null);
@@ -68,16 +70,22 @@ export function Slider({
 
   const { values, trackRect, focused, dragging }: State = state;
 
-  function dispatchChangeEvent(callback) {
-    const currentInput =
-      focused === 'startHandle' || focused === 'startInput'
-        ? startHandleRef
-        : endHandleRef;
+  const dispatchChangeEvent = useCallback(
+    (callback) => {
+      let currentInput =
+        focused === 'startHandle' || focused === 'startInput'
+          ? startHandleRef
+          : endHandleRef;
 
-    const event = new Event('change', { bubbles: true });
-    (currentInput || startHandleRef).current?.dispatchEvent(event);
-    callback && callback(event);
-  }
+      if (!currentInput.current) currentInput = startHandleRef;
+
+      const event = new Event('change', { bubbles: true });
+      currentInput.current?.dispatchEvent(event);
+
+      callback && callback(event);
+    },
+    [focused]
+  );
 
   function setDragging(payload) {
     if (payload) setFocus(payload);
@@ -85,7 +93,6 @@ export function Slider({
   }
 
   function setValue(payload) {
-    dispatchChangeEvent(onChange);
     return dispatch({ type: 'SET_VALUES', payload });
   }
 
@@ -112,8 +119,25 @@ export function Slider({
   }, [dragging]);
 
   useEffect(() => {
-    const mouseup = () => {
+    if (!isFirstRender.current) {
+      dispatchChangeEvent(onChange);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onChange, values]);
+
+  useEffect(() => {
+    if (!isFirstRender.current && !dragging) {
       dispatchChangeEvent(onDragEnd);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onDragEnd, dragging]);
+
+  useEffect(() => {
+    isFirstRender.current = false;
+  }, []);
+
+  useEffect(() => {
+    const mouseup = () => {
       dragging && setDragging(false);
     };
 

--- a/src/components/inputs/Slider/Slider.tsx
+++ b/src/components/inputs/Slider/Slider.tsx
@@ -124,6 +124,7 @@ export function Slider({
     } else {
       isFirstRender.current = false;
     }
+    // dispatchChangeEvent is updated on focus change and we want this flow to fire only on values / onChange updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onChange, values]);
 

--- a/src/components/inputs/Slider/Slider.tsx
+++ b/src/components/inputs/Slider/Slider.tsx
@@ -121,13 +121,11 @@ export function Slider({
   useEffect(() => {
     if (!isFirstRender.current) {
       dispatchChangeEvent(onChange);
+    } else {
+      isFirstRender.current = false;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onChange, values]);
-
-  useEffect(() => {
-    isFirstRender.current = false;
-  }, []);
 
   useEffect(() => {
     const mouseup = () => {


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does 
* Prevents the slider firing a change event on initial render.
* Make sure the value provided is not stale.

## Screenshots & Recordings 
https://github.com/vimeo/iris/assets/9106375/a47eff97-31cb-49d5-940c-df351bcfb4c0


## How it does that 
1. In the "old" slider version it was using a `useEffect` of value change to fire the event.
I wanted to avoid waiting for render cycle to finish before sending the event but because the event is bound to a DOM element that must have the correct value I had to bring the `useEffect` back.

2. Don't fire on first render, using a ref to check this is not the first render like in `DateRange`.

## Testing
* Added a unit test to make sure event doesn't fire on load.
* Change values in input and see value is correct.
