### PR TITLE
Fix: ColorSelect2 component doesn't close if outside click target stops propagation

### DIFF
--- a/src/components/inputs/ColorSelect2/ColorSelect2.test.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.test.tsx
@@ -5,6 +5,7 @@ import {
   render,
   RenderOptions,
   screen,
+  act,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ColorSelect2 } from './ColorSelect2';
@@ -34,7 +35,7 @@ describe('ColorSelect2', () => {
   it('Renders ColorSelect2 picker using input', async () => {
     renderWithThemeProvider(<ColorSelect2 />);
     const input = screen.getByLabelText('color');
-    await userEvent.click(input);
+    await act(async () => await userEvent.click(input));
     const picker = screen.getByLabelText('color picker');
     expect(picker).toBeInTheDocument();
   });
@@ -46,7 +47,7 @@ describe('ColorSelect2', () => {
       </ColorSelect2>
     );
     const trigger = screen.getByTestId('trigger');
-    await userEvent.click(trigger);
+    await act(async () => await userEvent.click(trigger));
     const picker = screen.getByLabelText('color picker');
     expect(picker).toBeInTheDocument();
   });
@@ -54,7 +55,7 @@ describe('ColorSelect2', () => {
   it('Set ColorSelect2 color using value prop', async () => {
     renderWithThemeProvider(<ColorSelect2 value={TEST_COLOR} />);
     const input = screen.getByLabelText('color');
-    await userEvent.click(input);
+    await act(async () => await userEvent.click(input));
 
     const selectedColor = screen.getByLabelText('color preview');
     const selectedColorValue = selectedColor.getAttribute('color');
@@ -64,7 +65,7 @@ describe('ColorSelect2', () => {
   it('Change ColorSelect2 color using input', async () => {
     renderWithThemeProvider(<ColorSelect2 />);
     const input = screen.getByLabelText('color');
-    await userEvent.click(input);
+    await act(async () => await userEvent.click(input));
 
     fireEvent.change(input, { target: { value: TEST_COLOR } });
 
@@ -78,9 +79,9 @@ describe('ColorSelect2', () => {
 
     renderWithThemeProvider(<ColorSelect2 onChange={mockFn} />);
     const input = screen.getByLabelText('color');
-    await userEvent.click(input);
+    await act(async () => await userEvent.click(input));
 
-    fireEvent.change(input, { target: { value: TEST_COLOR } });
+    await fireEvent.change(input, { target: { value: TEST_COLOR } });
 
     expect(mockFn).toBeCalledWith(TEST_COLOR);
   });
@@ -90,8 +91,8 @@ describe('ColorSelect2', () => {
 
     renderWithThemeProvider(<ColorSelect2 onClose={mockFn} />);
     const input = screen.getByLabelText('color');
-    await userEvent.click(input);
-    await userEvent.click(input); // Another click to close the picker
+    await act(async () => await userEvent.click(input));
+    await act(async () => await userEvent.click(input)); // Another click to close the picker
 
     expect(mockFn).toBeCalled();
   });
@@ -101,12 +102,12 @@ describe('ColorSelect2', () => {
 
     renderWithThemeProvider(<ColorSelect2 reset={reset} />);
     const input = screen.getByLabelText('color');
-    await userEvent.click(input);
+    await act(async () => await userEvent.click(input));
 
     fireEvent.change(input, { target: { value: TEST_COLOR } });
 
     const resetButton = screen.getByLabelText('reset');
-    await userEvent.click(resetButton);
+    await act(async () => await userEvent.click(resetButton));
 
     const selectedColor = screen.getByLabelText('color preview');
     const selectedColorValue = selectedColor.getAttribute('color');
@@ -141,7 +142,7 @@ describe('ColorSelect2', () => {
     renderWithThemeProvider(<ColorSelect2 required />);
 
     const input = screen.getByLabelText('color');
-    await userEvent.click(input);
+    await act(async () => await userEvent.click(input));
 
     const picker = screen.getByLabelText('color picker');
     const pickerInner = picker.querySelector('div');
@@ -158,7 +159,7 @@ describe('ColorSelect2', () => {
     renderWithThemeProvider(<ColorSelect2 name={name} />);
 
     const input = screen.getByLabelText('color');
-    await userEvent.click(input);
+    await act(async () => await userEvent.click(input));
 
     const picker = screen.getByLabelText('color picker');
     const pickerInner = picker.querySelector('div');
@@ -189,7 +190,7 @@ describe('ColorSelect2', () => {
   it('Render ColorSelect2 without hue slider', async () => {
     renderWithThemeProvider(<ColorSelect2 showHueSlider={false} />);
     const input = screen.getByLabelText('color');
-    await userEvent.click(input);
+    await act(async () => await userEvent.click(input));
 
     const hueSlider = document.querySelector('[kind=hue]');
 
@@ -209,7 +210,7 @@ describe('ColorSelect2', () => {
     );
 
     const preset = screen.getByLabelText(palette[1]);
-    await userEvent.click(preset);
+    await act(async () => await userEvent.click(preset));
 
     expect(mockFn).toBeCalledWith(palette[1]);
   });

--- a/src/components/inputs/ColorSelect2/ColorSelect2.test.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.test.tsx
@@ -6,6 +6,7 @@ import {
   RenderOptions,
   screen,
   act,
+  waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ColorSelect2 } from './ColorSelect2';
@@ -239,7 +240,7 @@ describe('ColorSelect2', () => {
 
     renderWithThemeProvider(
       <>
-        <ColorSelect2 />
+        <ColorSelect2 onClose={mockFn} />
         <button id="test_button">Test Button</button>
       </>
     );
@@ -247,10 +248,10 @@ describe('ColorSelect2', () => {
     const input = screen.getByLabelText('color');
     const button = screen.getByText('Test Button');
 
-    await act(async () => await userEvent.click(input));
+    await act(async () => await userEvent.click(input)); // Open the color picker.
 
-    await act(async () => await userEvent.click(button)); // Click on the button to trigger an outside click.
+    await act(async () => await userEvent.click(button)); // Trigger an outside click to close the picker.
 
-    expect(mockFn).toBeCalled();
+    await waitFor(() => expect(mockFn).toBeCalled());
   });
 });

--- a/src/components/inputs/ColorSelect2/ColorSelect2.test.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.test.tsx
@@ -254,4 +254,28 @@ describe('ColorSelect2', () => {
 
     await waitFor(() => expect(mockFn).toBeCalled());
   });
+
+  it('Closes the color picker on outside click, with stopPropagation() called on click target', async () => {
+    const mockFn = jest.fn();
+
+    renderWithThemeProvider(
+      <>
+        <ColorSelect2 onClose={mockFn} />
+        <button id="test_button">Test Button</button>
+      </>
+    );
+
+    const input = screen.getByLabelText('color');
+    const button = screen.getByText('Test Button');
+
+    button.addEventListener('click', (event) =>
+      event.stopPropagation()
+    );
+
+    await act(async () => await userEvent.click(input)); // Open the color picker.
+
+    await act(async () => await userEvent.click(button)); // Trigger an outside click to close the picker.
+
+    await waitFor(() => expect(mockFn).toBeCalled());
+  });
 });

--- a/src/components/inputs/ColorSelect2/ColorSelect2.test.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.test.tsx
@@ -233,4 +233,24 @@ describe('ColorSelect2', () => {
 
     expect(renderedLabel.innerHTML).toBe(label);
   });
+
+  it('Closes the color picker on outside click', async () => {
+    const mockFn = jest.fn();
+
+    renderWithThemeProvider(
+      <>
+        <ColorSelect2 />
+        <button id="test_button">Test Button</button>
+      </>
+    );
+
+    const input = screen.getByLabelText('color');
+    const button = screen.getByText('Test Button');
+
+    await act(async () => await userEvent.click(input));
+
+    await act(async () => await userEvent.click(button)); // Click on the button to trigger an outside click.
+
+    expect(mockFn).toBeCalled();
+  });
 });

--- a/src/components/inputs/ColorSelect2/ColorSelect2.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.tsx
@@ -53,8 +53,8 @@ function ColorSelectComponent({
     [childrenRef, popOverRef],
     () => {
       if (state.open) {
-        onClose?.();
         dispatch({ type: 'CLOSE', payload: true });
+        onClose?.();
       }
     },
     { useCapture: true }

--- a/src/components/inputs/ColorSelect2/ColorSelect2.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.tsx
@@ -49,12 +49,16 @@ function ColorSelectComponent({
   const childrenRef = useRef();
   const popOverRef = useRef();
 
-  useOutsideClick([childrenRef, popOverRef], () => {
-    if (state.open) {
-      onClose?.();
-      dispatch({ type: 'CLOSE', payload: true });
-    }
-  });
+  useOutsideClick(
+    [childrenRef, popOverRef],
+    () => {
+      if (state.open) {
+        onClose?.();
+        dispatch({ type: 'CLOSE', payload: true });
+      }
+    },
+    { useCapture: true }
+  );
 
   const defaultColor = parseToHsl(initial.color);
   const initialColors = colorSpaces(defaultColor);

--- a/src/components/inputs/ColorSelect2/ColorSelect2.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.tsx
@@ -57,7 +57,7 @@ function ColorSelectComponent({
         onClose?.();
       }
     },
-    { useCapture: true }
+    { capture: true }
   );
 
   const defaultColor = parseToHsl(initial.color);

--- a/src/utils/hooks/useOutsideClick.ts
+++ b/src/utils/hooks/useOutsideClick.ts
@@ -31,8 +31,8 @@ export function useOutsideClick(
     document.addEventListener('mousedown', click, useCapture);
     document.addEventListener('touchstart', click, useCapture);
     return () => {
-      document.removeEventListener('mousedown', click);
-      document.removeEventListener('touchstart', click);
+      document.removeEventListener('mousedown', click, useCapture);
+      document.removeEventListener('touchstart', click, useCapture);
     };
   }, [refs, onClick, options]);
 }

--- a/src/utils/hooks/useOutsideClick.ts
+++ b/src/utils/hooks/useOutsideClick.ts
@@ -7,10 +7,14 @@ import {
 type Element = HTMLElement | null;
 type Ref = MutableRefObject<Element>;
 type Refs = MutableRefObject<Element>[];
+type OutsideClickOptions = {
+  useCapture?: boolean;
+};
 
 export function useOutsideClick(
   refs: Ref | Refs,
-  onClick: MouseEventHandler
+  onClick: MouseEventHandler,
+  options?: OutsideClickOptions
 ) {
   useEffect(() => {
     if (!onClick) return;
@@ -22,11 +26,13 @@ export function useOutsideClick(
       if (outside) onClick(event);
     }
 
-    document.addEventListener('mousedown', click);
-    document.addEventListener('touchstart', click);
+    const useCapture = options?.useCapture || false;
+
+    document.addEventListener('mousedown', click, useCapture);
+    document.addEventListener('touchstart', click, useCapture);
     return () => {
       document.removeEventListener('mousedown', click);
       document.removeEventListener('touchstart', click);
     };
-  }, [refs, onClick]);
+  }, [refs, onClick, options]);
 }

--- a/src/utils/hooks/useOutsideClick.ts
+++ b/src/utils/hooks/useOutsideClick.ts
@@ -8,7 +8,7 @@ type Element = HTMLElement | null;
 type Ref = MutableRefObject<Element>;
 type Refs = MutableRefObject<Element>[];
 type OutsideClickOptions = {
-  useCapture?: boolean;
+  capture?: boolean;
 };
 
 export function useOutsideClick(
@@ -26,13 +26,13 @@ export function useOutsideClick(
       if (outside) onClick(event);
     }
 
-    const useCapture = options?.useCapture || false;
+    const capture = options?.capture || false;
 
-    document.addEventListener('mousedown', click, useCapture);
-    document.addEventListener('touchstart', click, useCapture);
+    document.addEventListener('mousedown', click, capture);
+    document.addEventListener('touchstart', click, capture);
     return () => {
-      document.removeEventListener('mousedown', click, useCapture);
-      document.removeEventListener('touchstart', click, useCapture);
+      document.removeEventListener('mousedown', click, capture);
+      document.removeEventListener('touchstart', click, capture);
     };
   }, [refs, onClick, options]);
 }


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
This PR is a bugfix.

The Color Picker component uses the useOutsideClick utility hook.
The hook listens to clicks anywhere on the page, and checks if the click target is inside the Color Picker or not. If not, it triggers the closing of the picker.

**The bug:** If the click target has a previously triggered listener that calls `event.stopPropagation()`, the event doesn't bubble up to the outside click listener, and hence is not handled and the picker remains open.

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->
Here is the bug:

https://github.com/vimeo/iris/assets/36724484/556903b5-5092-4896-8dc2-7c6f6f65ae9d

## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->
* This PR adds an optional parameter to the `useOutsideClick` hook, to allow for using the `useCapture` parameter in the click listeners.
* The `useCapture` parameter triggers the click listener targets immediately, instead of upon propagation. This way, the event is handled even if the target called `stopPropagation`.
* The PR added a usage of the new `useCapture` option in the color picker.

## Testing <!-- instructions on how to test -->
1. Open a blank canvas in the _new_ editor
2. In the left sidebar, click on Graphics, then on "Add solid background"
3. Open the color picker and change the color of the solid background. DON'T CLOSE THE PICKER.
4. With the picker open, go to the timeline, and drag the solid to trim/expand it, and release the mouse button.

**Current behavior (bug):**
The solid color resets to the default/previous color

**Expected behavior (after fix):**
The newly selected color remains the same after trimming.
Editor works as it should in all other aspects (no slowness, no issues with style resets...)