### PR TITLE
Update update-baseline workflow: ensures ownership of files in workflow

### DIFF
--- a/.github/workflows/update-baselines.yml
+++ b/.github/workflows/update-baselines.yml
@@ -70,6 +70,10 @@ jobs:
         uses: lost-pixel/lost-pixel@v3.4.1
         env:
           LOST_PIXEL_MODE: update
+      - name: ensure runner has ownership of all files created as part of workflow
+        if: ${{ failure() && steps.lp.conclusion == 'failure' }}
+        run: |
+          sudo chown -R runner:runner $GITHUB_WORKSPACE
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         if: ${{ failure() && steps.lp.conclusion == 'failure' }}


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Adds sudo command to ensure the ownership of files created as part of the workflow, resolves `error: The following untracked working tree files would be overwritten by checkout:` in update-baseline workflow.

