### PR TITLE
Fix padding sidebar button

### DIFF
--- a/src/components/Sidebar/Sidebar.minors.tsx
+++ b/src/components/Sidebar/Sidebar.minors.tsx
@@ -53,9 +53,6 @@ const ItemStyled = styled(Button)<{
   activeStyles?: ActiveStyles;
 }>`
   height: 3rem;
-  text-align: left;
-  padding: 0.25rem 0.25rem 0.25rem 0.75rem;
-  justify-content: start;
   ${({ isActive, activeStyles }) =>
     isActive && activeStyles ? activeStyles : ''};
 


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Visual bug, fixes centering svg on sidebar button: 

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->
Uncentered:

![image (1)](https://github.com/vimeo/iris/assets/22207955/45ad07cc-8d79-4af5-9936-1a70521fd7ce)


Centered: 
https://github.com/vimeo/iris/assets/22207955/c6793ed1-d55a-4835-af1e-aa93d6262cc2


## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->
Removes CSS rules from sidebar button:
```
text-align: left;
padding: 0.25rem 0.25rem 0.25rem 0.75rem;
justify-content: start;
```
## Testing <!-- instructions on how to test -->
Storybook: https://vimeo.github.io/iris/sb/sidebar-button/?path=/story/components-sidebar--controls
