### PR TITLE
Fix labeled sidebar accessibility

### DIFF
--- a/src/components/Sidebar/Sidebar.minors.tsx
+++ b/src/components/Sidebar/Sidebar.minors.tsx
@@ -6,6 +6,7 @@ import { ActiveStyles, ItemPropsIntrinsic } from './Sidebar.types';
 import { Button } from '../Button/Button';
 import { Tip } from '../Tip/Tip';
 import { core } from '../../tokens';
+import { Focus } from '../../utils';
 
 export function Item({
   attach = 'right',
@@ -110,6 +111,11 @@ const ItemLabelledStyled = styled(Button)<{
     font-size: 0.6875rem;
     line-height: initial;
     white-space: initial;
+  }
+
+  > ${Focus} {
+    // Accounts for the negative side margin, causing the focus ring to not be visible
+    border-width: 0.4rem;
   }
 `;
 


### PR DESCRIPTION
## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
Due to a negative margin for labeled buttons, the blue focus ring is obscurred. This PR adjusts the focus ring for labeled items only so that it is visible again

## Screenshots & Recordings 
![Screenshot 2023-07-31 at 12 27 52 PM](https://github.com/vimeo/iris/assets/2123735/863b28d0-8ba3-410f-b070-744b3c6971fa)

## Testing <!-- instructions on how to test -->
Easily test on storybook. Select a sidebar item and then press tab. The next item in the sidebar should show a blue focus ring
