### PR TITLE
Fix start of label being truncated, ellipsis for overflow

### DIFF
--- a/src/components/Sidebar/Sidebar.minors.tsx
+++ b/src/components/Sidebar/Sidebar.minors.tsx
@@ -54,9 +54,6 @@ const ItemStyled = styled(Button)<{
   activeStyles?: ActiveStyles;
 }>`
   height: 3rem;
-  text-align: left;
-  padding: 0.25rem 0.25rem 0.25rem 0.75rem;
-  justify-content: start;
   ${({ isActive, activeStyles }) =>
     isActive && activeStyles ? activeStyles : ''};
 

--- a/src/components/Sidebar/Sidebar.minors.tsx
+++ b/src/components/Sidebar/Sidebar.minors.tsx
@@ -1,3 +1,4 @@
+import { rem } from 'polished';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -104,10 +105,13 @@ const ItemLabelledStyled = styled(Button)<{
   // Button label
   > span {
     font-weight: 400;
-    text-overflow: initial;
     font-size: 0.6875rem;
     line-height: initial;
     white-space: initial;
+    width: calc(100% + ${rem(8)});
+    margin-left: ${rem(-4)};
+    margin-right: ${rem(-4)};
+    text-overflow: ellipsis;
   }
 
   > ${Focus} {

--- a/src/components/Sidebar/Sidebar.story.tsx
+++ b/src/components/Sidebar/Sidebar.story.tsx
@@ -83,6 +83,14 @@ const Template: Story<
           <Header size="3">Settings</Header>
         </Sidebar.Item>
 
+        <Sidebar.Item
+          label="Configurações"
+          labelAsTooltip={labelAsTooltip}
+          icon={<Gear />}
+        >
+          <Header size="3">Configurações</Header>
+        </Sidebar.Item>
+
         {!labelAsTooltip ? (
           <Sidebar.Item
             label="Longer Label"


### PR DESCRIPTION
## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
This PR is currently rebased off the `sidebar-button` branch. It fixes a bug in which the start of a long word is being truncated and the overflow is being cut off, rather than using ellipsis.

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->

| Before | After |
|--------|-------|
| <img width="85" alt="Screenshot 2023-07-31 at 12 02 26 PM" src="https://github.com/vimeo/iris/assets/47210101/ef2b0b44-2024-4cd9-af9d-8cbc89096b1f"> | <img width="85" alt="Screenshot 2023-07-31 at 12 02 13 PM" src="https://github.com/vimeo/iris/assets/47210101/d9fb4756-21db-4e8f-96af-c83ab0bda2ab"> |