### PR TITLE
fix(slider): don't dispatch onDragEnd if wasn't dragged

### DIFF
--- a/src/components/inputs/Slider/Slider.tsx
+++ b/src/components/inputs/Slider/Slider.tsx
@@ -130,8 +130,10 @@ export function Slider({
 
   useEffect(() => {
     const mouseup = () => {
-      dragging && setDragging(false);
-      dispatchChangeEvent(onDragEnd);
+      if (dragging) {
+        setDragging(false);
+        dispatchChangeEvent(onDragEnd);
+      }
     };
 
     const keydown = (event) => {


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
* dispatch the onDragEnd event only if we finished dragging and not on every mouseup event

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->

## How it does that <!-- implementation details, design decisions, info to help the PR reviewer, etc -->

## Testing <!-- instructions on how to test -->

