### PR TITLE
CEWK-2840 ColorSelect2 redesign, move presets into popover, add disabled props

### DIFF
--- a/src/components/inputs/ColorSelect2/ColorSelect2.style.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.style.tsx
@@ -10,7 +10,7 @@ export const Wrapper = styled.div<{
   height: number;
   showHueSlider: boolean;
 }>`
-  padding: 0;
+  padding: 1rem;
   position: relative;
   width: ${(p) => p.width}px;
   border-radius: 0.25rem;
@@ -33,32 +33,14 @@ export const Wrapper = styled.div<{
   .react-colorful__hue {
     display: ${({ showHueSlider }) =>
       showHueSlider ? 'block' : 'none'};
-    margin: 1.5rem 1.5rem 0 4rem;
+    margin: 1.5rem 0;
+    border-radius: 1rem;
   }
 
   .react-colorful__saturation-pointer {
     width: 1.25rem;
     height: 1.25rem;
   }
-`;
-
-export const SelectedColor = styled.div.attrs(
-  ({ color }: { color: string }) => ({
-    style: {
-      background: color,
-    },
-  })
-)<{ color: string }>`
-  position: absolute;
-  left: 1.5rem;
-  bottom: 0;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-`;
-
-export const ColorSelectPickerWrapper = styled.div`
-  position: relative;
 `;
 
 export const Dot = styled.div`

--- a/src/components/inputs/ColorSelect2/ColorSelect2.test.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.test.tsx
@@ -57,10 +57,7 @@ describe('ColorSelect2', () => {
     renderWithThemeProvider(<ColorSelect2 value={TEST_COLOR} />);
     const input = screen.getByLabelText('color');
     await act(async () => await userEvent.click(input));
-
-    const selectedColor = screen.getByLabelText('color preview');
-    const selectedColorValue = selectedColor.getAttribute('color');
-    expect(selectedColorValue).toBe(TEST_COLOR);
+    expect((input as HTMLInputElement).value).toBe(TEST_COLOR);
   });
 
   it('Change ColorSelect2 color using input', async () => {
@@ -70,9 +67,7 @@ describe('ColorSelect2', () => {
 
     fireEvent.change(input, { target: { value: TEST_COLOR } });
 
-    const selectedColor = screen.getByLabelText('color preview');
-    const selectedColorValue = selectedColor.getAttribute('color');
-    expect(selectedColorValue).toBe(TEST_COLOR);
+    expect((input as HTMLInputElement).value).toBe(TEST_COLOR);
   });
 
   it('Fires onChange callback', async () => {
@@ -110,9 +105,7 @@ describe('ColorSelect2', () => {
     const resetButton = screen.getByLabelText('reset');
     await act(async () => await userEvent.click(resetButton));
 
-    const selectedColor = screen.getByLabelText('color preview');
-    const selectedColorValue = selectedColor.getAttribute('color');
-    expect(selectedColorValue).toBe(reset.color);
+    expect((input as HTMLInputElement).value).toBe(reset.color);
   });
 
   it('Change size', async () => {
@@ -199,16 +192,15 @@ describe('ColorSelect2', () => {
   });
 
   it('Select color from presets', async () => {
-    const palette = ['#909CDC', '#7BD8DB', '#78DD89', '#CCE190'];
+    const palette = ['#909CDC', '#7BD8DB', '#78DD89'];
     const mockFn = jest.fn();
 
     renderWithThemeProvider(
-      <ColorSelect2.Presets
-        palette={palette}
-        label="Presets"
-        onColorClick={mockFn}
-      />
+      <ColorSelect2 onChange={mockFn} presets={{ palette }} />
     );
+
+    const input = screen.getByLabelText('color');
+    await act(async () => await userEvent.click(input));
 
     const preset = screen.getByLabelText(palette[1]);
     await act(async () => await userEvent.click(preset));
@@ -217,20 +209,17 @@ describe('ColorSelect2', () => {
   });
 
   it('Render a label for presets', async () => {
-    const palette = ['#909CDC', '#7BD8DB', '#78DD89', '#CCE190'];
+    const palette = ['#909CDC', '#7BD8DB', '#78DD89'];
     const label = 'My Label';
 
     renderWithThemeProvider(
-      <ColorSelect2.Presets
-        palette={palette}
-        label={label}
-        onColorClick={() => {
-          console.log('click ');
-        }}
-      />
+      <ColorSelect2 presets={{ palette, label }} />
     );
 
-    const renderedLabel = document.querySelector('h6');
+    const input = screen.getByLabelText('color');
+    await act(async () => await userEvent.click(input));
+
+    const renderedLabel = document.querySelector('p');
 
     expect(renderedLabel.innerHTML).toBe(label);
   });
@@ -277,5 +266,17 @@ describe('ColorSelect2', () => {
     await act(async () => await userEvent.click(button)); // Trigger an outside click to close the picker.
 
     await waitFor(() => expect(mockFn).toBeCalled());
+  });
+
+  it('ColorSelect2 input should be disabled', async () => {
+    renderWithThemeProvider(<ColorSelect2 disabled />);
+    const input = screen.getByLabelText('color');
+    expect(input).toBeDisabled();
+  });
+
+  it('ColorSelect2 reset button should be disabled', async () => {
+    renderWithThemeProvider(<ColorSelect2 disabled />);
+    const resetButton = screen.getByLabelText('reset');
+    expect(resetButton).toBeDisabled();
   });
 });

--- a/src/components/inputs/ColorSelect2/ColorSelect2.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.tsx
@@ -8,12 +8,11 @@ import { State, reducer } from './ColorSelect2.state';
 import { ColorInputs } from './Inputs';
 import { ColorSelectInput } from './ColorSelect2Input';
 import { ColorSelectPicker } from './ColorSelect2Picker';
-import { Presets, Props as PresetsProps } from './Presets';
+import { Presets } from './Presets';
 
 import { PopOver } from '../../PopOver/PopOver';
 import {
   withIris,
-  MinorComponent,
   useOutsideClick,
 } from '../../../utils';
 import { colorSpaces } from '../../../color';
@@ -24,11 +23,8 @@ import { colorSpaces } from '../../../color';
  */
 export const ColorSelect2 = withIris<
   HTMLInputElement,
-  Props,
-  { Presets: MinorComponent<PresetsProps> }
+  Props
 >(ColorSelectComponent);
-
-ColorSelect2.Presets = Presets;
 
 function ColorSelectComponent({
   children,
@@ -45,6 +41,8 @@ function ColorSelectComponent({
   width = 360,
   attach = 'bottom',
   showHueSlider = true,
+  disabled,
+  presets,
 }: Props) {
   const childrenRef = useRef();
   const popOverRef = useRef();
@@ -95,6 +93,18 @@ function ColorSelectComponent({
           showHueSlider={showHueSlider}
           ref={popOverRef}
         >
+          {presets && (
+            <Presets
+              selectedColor={colorMeta.HEX}
+              palette={presets.palette}
+              label={presets.label}
+              onEdit={presets.onEdit}
+              onSelect={(color: string) => {
+                dispatch({ type: 'SET_HEX', payload: color });
+                onChange(color);
+              }}
+            />
+          )}
           <ColorSelectPicker
             dispatch={dispatch}
             onChange={onChange}
@@ -110,7 +120,7 @@ function ColorSelectComponent({
       }
     >
       {children ? (
-        <div onClick={toggle} ref={childrenRef}>
+        <div onClick={() => !disabled && toggle()} ref={childrenRef}>
           {children}
         </div>
       ) : (
@@ -123,6 +133,7 @@ function ColorSelectComponent({
             reset={reset}
             size={size}
             toggle={toggle}
+            disabled={disabled}
           />
         </div>
       )}

--- a/src/components/inputs/ColorSelect2/ColorSelect2.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.tsx
@@ -11,20 +11,16 @@ import { ColorSelectPicker } from './ColorSelect2Picker';
 import { Presets } from './Presets';
 
 import { PopOver } from '../../PopOver/PopOver';
-import {
-  withIris,
-  useOutsideClick,
-} from '../../../utils';
+import { withIris, useOutsideClick } from '../../../utils';
 import { colorSpaces } from '../../../color';
 
 /**
  * An input that enables users to choose a color from a predefined range of colors from a color picker panel.
  * This components precedes the eventual deprecation of ColorPicker.tsx to ease migration and ensure backwards compatibility.
  */
-export const ColorSelect2 = withIris<
-  HTMLInputElement,
-  Props
->(ColorSelectComponent);
+export const ColorSelect2 = withIris<HTMLInputElement, Props>(
+  ColorSelectComponent
+);
 
 function ColorSelectComponent({
   children,

--- a/src/components/inputs/ColorSelect2/ColorSelect2.types.ts
+++ b/src/components/inputs/ColorSelect2/ColorSelect2.types.ts
@@ -3,6 +3,12 @@ import { ReactNode } from 'react';
 
 import { Attach, AttachAlias } from '../../../utils';
 
+export type Presets = {
+  palette: string[];
+  label?: string;
+  onEdit?: () => void;
+};
+
 export type Props = IrisInputProps<{
   defaultValue?: string | string[];
   /**
@@ -54,4 +60,6 @@ export type Props = IrisInputProps<{
    * Shows hue slider, default = true
    */
   showHueSlider?: boolean;
+  disabled?: boolean;
+  presets?: Presets;
 }>;

--- a/src/components/inputs/ColorSelect2/ColorSelect2Input.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2Input.tsx
@@ -16,6 +16,7 @@ export function ColorSelectInput({
   reset,
   size,
   toggle,
+  disabled,
 }) {
   const ref = useRef();
   const { HEX } = colorMeta;
@@ -38,6 +39,7 @@ export function ColorSelectInput({
   return (
     <div style={{ position: 'relative' }}>
       <Input
+        disabled={disabled}
         label={label}
         onClick={toggle}
         ref={ref}
@@ -56,6 +58,7 @@ export function ColorSelectInput({
         {reset.label &&
           HEX.toLowerCase() !== reset.color.toLowerCase() && (
             <InnerButton
+              disabled={disabled}
               aria-label="reset"
               format="basic"
               variant="minimalTransparent"

--- a/src/components/inputs/ColorSelect2/ColorSelect2Picker.tsx
+++ b/src/components/inputs/ColorSelect2/ColorSelect2Picker.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { HexColorPicker } from 'react-colorful';
 import { throttle } from '../../../utils';
-import {
-  ColorSelectPickerWrapper,
-  SelectedColor,
-} from './ColorSelect2.style';
 
 export function ColorSelectPicker({
   value,
@@ -18,9 +14,8 @@ export function ColorSelectPicker({
   }, throttleSpeed);
 
   return (
-    <ColorSelectPickerWrapper aria-label="color picker">
-      <SelectedColor color={value} aria-label="color preview" />
+    <div aria-label="color picker">
       <HexColorPicker color={value} onChange={handleChange} />
-    </ColorSelectPickerWrapper>
+    </div>
   );
 }

--- a/src/components/inputs/ColorSelect2/Inputs.tsx
+++ b/src/components/inputs/ColorSelect2/Inputs.tsx
@@ -41,13 +41,10 @@ export function ColorInputs({
     <>
       <Wrapper {...props}>
         <Button
-          format="soft"
+          format="secondary"
           onClick={cycle}
-          size="sm"
-          variant="outline"
           status={error ? 'negative' : null}
-          style={{ opacity: '0.667', marginRight: '1rem' }}
-          pill
+          style={{ height: '2.35rem' }}
         >
           {colorSpace}
         </Button>
@@ -125,7 +122,6 @@ function InputEdit({ value, dispatch, error, forwardRef, onChange }) {
       onKeyUp={onKeyUp}
       ref={forwardRef}
       status={error ? 'negative' : null}
-      style={{ display: 'inline-block' }}
       type="text"
     />
   );
@@ -138,7 +134,6 @@ function InputHEX({ colorMeta, onClick }) {
   return (
     <ColorInput
       value={HEX}
-      style={{ display: 'inline-block' }}
       {...props}
       readOnly
     />
@@ -189,7 +184,7 @@ function validate(color) {
 const ColorInput = styled(Input)`
   width: 100%;
   flex-grow: 1;
-  display: inline-flex;
+  display: inline-block;
 
   + div {
     margin-left: 0.334rem;
@@ -197,9 +192,8 @@ const ColorInput = styled(Input)`
 `;
 
 const Wrapper = styled.div`
-  padding: 0.5rem 1.5rem 1.5rem;
   width: 100%;
-  margin-top: 0.75rem;
   display: flex;
   align-items: center;
+  gap: 0.5rem;
 `;

--- a/src/components/inputs/ColorSelect2/Inputs.tsx
+++ b/src/components/inputs/ColorSelect2/Inputs.tsx
@@ -131,13 +131,7 @@ function InputHEX({ colorMeta, onClick }) {
   const { HEX } = colorMeta;
   const props = { onClick, type: 'text' } as const;
 
-  return (
-    <ColorInput
-      value={HEX}
-      {...props}
-      readOnly
-    />
-  );
+  return <ColorInput value={HEX} {...props} readOnly />;
 }
 
 function InputRGB({ colorMeta, onClick }) {

--- a/src/components/inputs/ColorSelect2/Presets.story.tsx
+++ b/src/components/inputs/ColorSelect2/Presets.story.tsx
@@ -7,8 +7,8 @@ import { Props } from './Presets';
 import { Layout } from '../../../storybook';
 
 export default {
-  title: 'components/ColorSelect2/minors',
-  component: ColorSelect2.Presets,
+  title: 'components/ColorSelect2/Props',
+  component: ColorSelect2,
   argTypes: {
     attach: { table: { disable: true } }, // not relevant
   },
@@ -17,24 +17,19 @@ export default {
 const Template: Story<Props> = (args) => {
   const [accentColor, setAccentColor] = useState('#00adef');
 
+  const { palette, label, onEdit } = args;
+
   return (
     <Layout.StoryVertical>
       <ColorSelect2
-        label={
-          <div>
-            <ColorSelect2.Presets
-              {...args}
-              onColorClick={(color) => {
-                setAccentColor(color);
-              }}
-            />
-          </div>
-        }
+        presets={{
+          palette,
+          label: label as string,
+          onEdit,
+        }}
         width={300}
         height={150}
-        onChange={(color) => {
-          setAccentColor(color);
-        }}
+        onChange={(color) => setAccentColor(color)}
         value={accentColor}
       />
     </Layout.StoryVertical>
@@ -42,8 +37,9 @@ const Template: Story<Props> = (args) => {
 };
 
 export const PresetControls = Template.bind({});
-PresetControls.storyName = 'ColorSelect2.Presets';
+PresetControls.storyName = 'Presets';
 PresetControls.args = {
-  palette: ['#909CDC', '#7BD8DB', '#78DD89', '#CCE190'],
+  palette: ['#909CDC', '#7BD8DB', '#78DD89'],
   label: 'Presets',
+  onEdit: () => alert('Editing presets'),
 };

--- a/src/components/inputs/ColorSelect2/Presets.tsx
+++ b/src/components/inputs/ColorSelect2/Presets.tsx
@@ -2,77 +2,122 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { rem } from 'polished';
 
-import { Header } from '../../../typography';
+import { Paragraph } from '../../../typography';
 import { Focus } from '../../../utils';
+import { blue } from '../../../color';
+import { Pencil } from '../../../icons';
+import { Button } from '../../Button/Button';
 
 export type Props = {
+  selectedColor: string;
   palette: string[];
-  label: string;
-  onColorClick: (color: string) => void;
+  label?: string;
+  onSelect: (color: string) => void;
+  onEdit?: () => void;
 };
 
-export function Presets({ palette, label, onColorClick }: Props) {
-  const [index, indexSet] = useState(0);
+export function Presets({
+  selectedColor,
+  palette,
+  label,
+  onSelect,
+  onEdit,
+}: Props) {
+  const [index, setIndex] = useState(0);
 
   const onKeyUp = ({ key }) => {
     if (key !== 'ArrowRight' && key !== 'ArrowLeft') return;
 
     let indexNext;
-    if (key === 'ArrowRight') indexNext = index === 3 ? 0 : index + 1;
-    if (key === 'ArrowLeft') indexNext = index === 0 ? 3 : index - 1;
+    if (key === 'ArrowRight')
+      indexNext = index === palette.length - 1 ? 0 : index + 1;
+    if (key === 'ArrowLeft')
+      indexNext = index === 0 ? palette.length - 1 : index - 1;
 
-    indexSet(indexNext);
-    onColorClick(palette[indexNext]);
+    setIndex(indexNext);
+    onSelect(palette[indexNext]);
   };
 
   return (
-    <Swabs>
+    <PresetsContainer>
       {label && (
-        <Header size="6" style={{ margin: '0 auto 0 0' }}>
+        <Paragraph size="1" style={{ margin: 0, fontWeight: 700 }}>
           {label}
-        </Header>
+        </Paragraph>
       )}
-      {palette.map((color: string) => (
-        <Swab
-          aria-label={color}
-          color={color}
-          key={color}
-          onClick={(event) => {
-            event.stopPropagation();
-            onColorClick(color);
-          }}
-          onKeyUp={onKeyUp}
-        >
-          <Focus parent={Swab} radius={12} />
-        </Swab>
-      ))}
-    </Swabs>
+      <Swabs>
+        {palette.map((color: string) => (
+          <SwabRing
+            selected={
+              selectedColor.toLowerCase() === color.toLowerCase()
+            }
+            key={color}
+            onClick={() => onSelect(color)}
+          >
+            <Swab
+              aria-label={color}
+              color={color}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSelect(color);
+              }}
+              onKeyUp={onKeyUp}
+            >
+              <Focus parent={Swab} radius={24} />
+            </Swab>
+          </SwabRing>
+        ))}
+        {onEdit && (
+          <Button
+            icon={<Pencil />}
+            size="sm"
+            variant="minimalTransparent"
+            format="basic"
+            onClick={onEdit}
+          />
+        )}
+      </Swabs>
+    </PresetsContainer>
   );
 }
 
-const Swabs = styled.div`
+const PresetsContainer = styled.div`
   display: flex;
   align-items: center;
   flex-direction: row;
+  margin-bottom: 1rem;
+`;
+
+const Swabs = styled.div`
+  margin-left: auto;
+  display: flex;
+  gap: ${rem(4)};
 `;
 
 const Swab = styled.button<{ color: string }>`
-  height: 1.125rem;
-  width: 1.125rem;
+  height: ${rem(24)};
+  width: ${rem(24)};
   border: ${rem(1)} solid rgba(0, 0, 0, 0.15);
   border-radius: 50%;
-  margin: 0 0 0 0.75rem;
   background-color: ${(p) => p.color};
   position: relative;
   outline: none;
-  transition: transform 0.2s ease-in-out;
   cursor: pointer;
+`;
+
+const SwabRing = styled.div<{ selected: boolean }>`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${rem(30)};
+  height: ${rem(30)};
+  border-radius: ${rem(24)};
+  border: ${({ selected }) =>
+    `${rem(2)} solid ${selected ? blue(500) : 'transparent'}`};
+  transition: 150ms ease-in-out;
 
   &:hover {
-    transform: scale(1.2);
-  }
-
-  &:active {
-    transform: scale(1);
+    border-color: ${(p) => p.theme.content.color};
   }
 `;


### PR DESCRIPTION
<!--
❗❗ COMPLETE ALL SECTIONS BELOW! ❗❗

If a section isn't relevant, remove it.
Do not leave it blank.
-->

Closes: https://vimean.atlassian.net/browse/CEWK-2840?focusedCommentId=786710&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-786710

## What this PR does <!-- Is it a bugfix? Feature? Why is this needed? -->
- Style `ColorSelect2` according to updated [design](https://www.figma.com/file/cA7cmTeW3cTaMNsnES5n1s/Proposals?type=design&node-id=3121-203665&mode=design)
- Add `disabled` prop to `ColorSelect2`
- Move `Presets` internally into the `ColorSelect2` popover according to [design](https://www.figma.com/file/cA7cmTeW3cTaMNsnES5n1s/Proposals?type=design&node-id=3142-205928&mode=design&t=5kRQ1lWO1EWivP8g-0) and add `presets` prop
- Update storybook
- Update & add tests

## Screenshots & Recordings <!-- It's really helpful to give your reviewer some extra context - A picture is worth a thousand words after all. -->
<img width="388" alt="Screenshot 2023-08-16 at 17 58 29" src="https://github.com/vimeo/iris/assets/59689809/c116ea75-eb36-4ef8-8f15-0f8acbe9c208">

## Testing <!-- instructions on how to test -->
- Run tests
